### PR TITLE
First conversion trial for Ptrdist/anagram benchmark

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -573,12 +573,13 @@ AddWords(void) {
             // pch[2..] = word itself
         {
             // FIXME
-            // - add addtional variable to represent words bounds (wordStart/wordEnd)
-            // - max word length is encoded in pch[0], use it
-            // - rewrite function call to hold bounds start/end in function argument
+            // - add addtional variable as word bounds (wordStart/wordEnd) not dictionary bounds
+            // - use word length encoded in pch[0]
+            // - rewrite function call to hold bounds of word in function argument
             unsigned char wordLength = pch[0];
             _Array_ptr<char> wordStart = pch;
             _Array_ptr<char> wordEnd = pch+wordLength;
+            _Dynamic_check(wordEnd <= pchUpperBounds);
             BuildWord(pch+2, wordStart, wordEnd);
         }
         // CHECKEDC : dereference(in-bounds check) && pointer arithmetic (non-null check only)
@@ -683,10 +684,10 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
         Stat(if (++ulLowCount == 0) ++ulHighCount;)
 
-            // CHECKEDC : checkedc array type array subscript
-            // aqNext[i], pqMask[i], pw->aqMask[i], aqMainSign[i]
-            // dynamic_check(i >= 0 && i < MAX_QUADS)
-            // In below macros, i is constant value (0/1/2/3)
+        // CHECKEDC : checkedc array type array subscript
+        // aqNext[i], pqMask[i], pw->aqMask[i], aqMainSign[i]
+        // dynamic_check(i >= 0 && i < MAX_QUADS)
+        // In below macros, i is constant value (0/1/2/3)
 #if MAX_QUADS > 0
         OneStep(0);                     /* lines of code. */
 #endif
@@ -708,8 +709,8 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 #endif
 
         /* If the pivot letter isn't present, defer this word until later */
-                // CHECKEDC : checkedc array type array subscript
-                // dynamic_check(iq >= 0 && iq < MAX_QUADS)
+        // CHECKEDC : checkedc array type array subscript
+        // dynamic_check(iq >= 0 && iq < MAX_QUADS)
         if ((pw->aqMask[iq] & qMask) == 0) {
             // CHECKEDC : pointer arithmetic(non-null check only) && dereference(in-bounds check)
             // dynamic_check(ppwStart != NULL && ppwEnd != NULL)
@@ -721,17 +722,17 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
         }
 
         /* If we get here, this means the word fits. */
-            // CHECKEDC : checkedc array type array subscript, in-bounds check
-            // dynamic_check(cpwLast >= 0 && cpwLast < MAXSOL)
+        // CHECKEDC : checkedc array type array subscript, in-bounds check
+        // dynamic_check(cpwLast >= 0 && cpwLast < MAXSOL)
         apwSol[cpwLast++] = pw;
         if (cchPhraseLength -= pw->cchLength) { /* recurse */
             Debug(DumpWords();)
             /* The recursive call scrambles the tail, so we have to be
              * pessimistic.
              */
-                // CHECKEDC : pointer arithmetic(non-null check only)
-                // dynamic_check(ppwEnd != NULL)
-                // dynamic_check((ppwEnd+cpwCand) >= apwCand && (ppwEnd+cpwCand) < (apwCand+MAXCAND))
+        // CHECKEDC : pointer arithmetic(non-null check only)
+        // dynamic_check(ppwEnd != NULL)
+        // dynamic_check((ppwEnd+cpwCand) >= apwCand && (ppwEnd+cpwCand) < (apwCand+MAXCAND))
 	    ppwEnd = &apwCand[0];
 	    ppwEnd += cpwCand;
         // CHECKEDC : function call actual argument passing

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
@@ -48,14 +48,14 @@
 #define INLINE
 #endif
 
-static HeapP * hTable[MAX_RANK];
+static _Ptr<HeapP> hTable _Checked[MAX_RANK];
 
-void  CombineLists(HeapP *, HeapP *);
-void  AddEntry(HeapP *, HeapP *);
-HeapP * RemoveEntry(HeapP *);
-HeapP * NewHeap(Item *);
-void  RemoveChild(HeapP *);
-void  FixRank(HeapP *, int);
+void  CombineLists(_Ptr<HeapP> , _Ptr<HeapP> );
+void  AddEntry(_Ptr<HeapP> , _Ptr<HeapP> );
+_Ptr<HeapP>  RemoveEntry(_Ptr<HeapP> );
+_Ptr<HeapP>  NewHeap(_Ptr<Item> );
+void  RemoveChild(_Ptr<HeapP> );
+void  FixRank(_Ptr<HeapP> , int);
 
 INLINE void
 InitFHeap()
@@ -64,18 +64,21 @@ InitFHeap()
 
   for(j = 0; j < MAX_RANK; j++)
   {
+      // CHECKEDC : checkedc array type array subscript
+      // dynamic_check(j >= 0 && j < MAX_RANK)
+      // : reasoning facts can optimize redundant bounds check
     hTable[j] = NULL;
   }
 }
 
-INLINE HeapP *
-MakeHeap()
+INLINE _Ptr<HeapP> 
+MakeHeap(void)
 {
   return(NULL);
 }
 
-INLINE Item *
-FindMin(HeapP * h)
+INLINE _Ptr<Item> 
+FindMin(_Ptr<HeapP>  h)
 {
   if(h == NULL)
   {
@@ -87,18 +90,19 @@ FindMin(HeapP * h)
   }
 }
 
-INLINE HeapP *
-Insert(HeapP * * h, Item * i)
+INLINE _Ptr<HeapP> 
+Insert(_Ptr<_Ptr<HeapP>>  h, _Ptr<Item>  i)
 {
-  HeapP * h1;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
 
   h1 = NewHeap(i);
   *h = Meld(*h, h1);
   return(h1);
 }
 
-INLINE HeapP *
-Meld(HeapP * h1, HeapP * h2)
+INLINE _Ptr<HeapP> 
+Meld(_Ptr<HeapP>  h1, _Ptr<HeapP>  h2)
 {
   if(h2 == NULL)
   {
@@ -122,14 +126,15 @@ Meld(HeapP * h1, HeapP * h2)
 /*
  * This function needs some aesthetic changes.
  */
-INLINE HeapP *
-DeleteMin(HeapP * h)
+INLINE _Ptr<HeapP> 
+DeleteMin(_Ptr<HeapP>  h)
 {
   int   r, rMax, j;
-  HeapP * h1;
-  HeapP * h2;
-  HeapP * h3;
-  HeapP * min;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
+  _Ptr<HeapP>  h2 = 0;
+  _Ptr<HeapP>  h3 = 0;
+  _Ptr<HeapP>  min = 0;
 
   rMax = 0;
 
@@ -142,7 +147,7 @@ DeleteMin(HeapP * h)
 
   if(h1 == NULL)
   {
-    free(h);
+    free((void*)h);
     return(NULL);
   }
 
@@ -168,6 +173,12 @@ DeleteMin(HeapP * h)
 
     r = RANK(h2);
     assert(r < MAX_RANK);
+
+    // CHECKEDC : checkedc array type array subscript
+    // dynamic_check(r >= 0 && r < MAX_RANK)
+    // : reasoning facts from assertion statement (r < MAX_RANK)
+    // can optimize redundant bounds check
+    // : instead of using assertion, it can be replaced with dynamic_check
     while(hTable[r] != NULL)
     {
       if(LessThan(ITEM(hTable[r]), ITEM(h2)))
@@ -209,6 +220,11 @@ DeleteMin(HeapP * h)
 
       r = RANK(h2);
       assert(r < MAX_RANK);
+      // CHECKEDC : checkedc array type array subscript
+      // dynamic_check(r >= 0 && r < MAX_RANK)
+      // : reasoning facts from assertion statement (r < MAX_RANK)
+      // can optimize redundant bounds check
+      // : instead of using assertion, it can be replaced with dynamic_check
       while(hTable[r] != NULL)
       {
         if(LessThan(ITEM(hTable[r]), ITEM(h2)))
@@ -241,6 +257,10 @@ DeleteMin(HeapP * h)
    */
   for(j = 0; j <= rMax; j++)
   {
+      // CHECKEDC : checkedc array type array subscript
+      // dynamic_check(j >= 0 && j < MAX_RANK)
+      // if there is programmer-inserted dynamic_check outside for-loop
+      // compiler can optimize away redundant bounds check
     if(hTable[j] != NULL)
     {
       break;
@@ -252,6 +272,10 @@ DeleteMin(HeapP * h)
   j++;
   for(; j <= rMax; j++)
   {
+      // CHECKEDC : checkedc array type array subscript
+      // dynamic_check(j >= 0 && j < MAX_RANK)
+      // if there is programmer-inserted dynamic_check outside for-loop
+      // compiler can optimize away redundant bounds check
     if(hTable[j] != NULL)
     {
       CombineLists(h1, hTable[j]);			/* TBD note that update to PARENT not necessary!! */
@@ -263,13 +287,13 @@ DeleteMin(HeapP * h)
     }
   }
 
-  free(h);
+  free((void*)h);
 
   return(min);
 }
 
-INLINE HeapP *
-DecreaseKey(HeapP * h, HeapP * i, int delta)
+INLINE _Ptr<HeapP> 
+DecreaseKey(_Ptr<HeapP>  h, _Ptr<HeapP>  i, int delta)
 {
   assert(h != NULL);
   assert(i != NULL);
@@ -294,9 +318,10 @@ DecreaseKey(HeapP * h, HeapP * i, int delta)
  * Note: i must have a parent (;-).
  */
 INLINE void
-RemoveChild(HeapP * i)
+RemoveChild(_Ptr<HeapP>  i)
 {
-  HeapP * parent;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  parent = 0;
 
   assert(i != NULL);
 
@@ -324,7 +349,7 @@ RemoveChild(HeapP * i)
 }
 
 INLINE void
-FixRank(HeapP * h, int delta)
+FixRank(_Ptr<HeapP>  h, int delta)
 {
   assert(h != NULL);
   assert(delta > 0);
@@ -337,11 +362,12 @@ FixRank(HeapP * h, int delta)
   while(h != NULL);
 }
 
-INLINE HeapP *
-Delete(HeapP * h, HeapP * i)
+INLINE _Ptr<HeapP> 
+Delete(_Ptr<HeapP>  h, _Ptr<HeapP>  i)
 {
-  HeapP * h1;
-  HeapP * h2;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
+  _Ptr<HeapP>  h2 = 0;
 
   assert(h != NULL);
   assert(i != NULL);
@@ -385,7 +411,7 @@ Delete(HeapP * h, HeapP * i)
     while(h1 != CHILD(i));
   }
 
-  free(i);
+  free((void*)i);
   return(h);
 }
 
@@ -403,9 +429,9 @@ Delete(HeapP * h, HeapP * i)
  *   none
  */
 INLINE void
-CombineLists(HeapP * h1, HeapP * h2)
+CombineLists(_Ptr<HeapP>  h1, _Ptr<HeapP>  h2)
 {
-  HeapP * h;
+  _Ptr<HeapP>  h = 0;
 
   assert((h1 != NULL) && (h2 != NULL));
 
@@ -432,7 +458,7 @@ CombineLists(HeapP * h1, HeapP * h2)
  *   h1 with h2 as new child of h1.
  */
 INLINE void
-AddEntry(HeapP * h1, HeapP * h2)
+AddEntry(_Ptr<HeapP>  h1, _Ptr<HeapP>  h2)
 {
   assert((h1 != NULL) && (h2 != NULL));
 
@@ -462,8 +488,8 @@ AddEntry(HeapP * h1, HeapP * h2)
  * Return values:
  *   a smaller heap, possibly NULL
  */
-INLINE HeapP *
-RemoveEntry(HeapP * h)
+INLINE _Ptr<HeapP> 
+RemoveEntry(_Ptr<HeapP>  h)
 {
   assert(h != NULL);
 
@@ -491,10 +517,11 @@ RemoveEntry(HeapP * h)
  * Return values:
  *   a single entry heap
  */
-INLINE HeapP *
-NewHeap(Item * i)
+INLINE _Ptr<HeapP> 
+NewHeap(_Ptr<Item>  i)
 {
-  HeapP * h;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h = 0;
 
   h = (HeapP *)malloc(sizeof(HeapP));
 
@@ -514,17 +541,18 @@ NewHeap(Item * i)
   return(h);
 }
 
-INLINE Item *
-ItemOf(HeapP * h)
+INLINE _Ptr<Item> 
+ItemOf(_Ptr<HeapP>  h)
 {
   return(ITEM(h));
 }
 
-INLINE HeapP *
-Find(HeapP * h, Item * item)
+INLINE _Ptr<HeapP> 
+Find(_Ptr<HeapP>  h, _Ptr<Item>  item)
 {
-  HeapP * h1;
-  HeapP * h2;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
+  _Ptr<HeapP>  h2 = 0;
 
   if(h == NULL)
   {

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
@@ -37,8 +37,9 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
+// CHECKED
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include "Fheap.h"
 #include "Fstruct.h"
 

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.h
@@ -53,12 +53,12 @@
 
 typedef struct _Heap
 {
-  Item *     item;
+  _Ptr<Item>      item;
 
-  struct _Heap * parent;
-  struct _Heap * child;
-  struct _Heap * forward;
-  struct _Heap * backward;
+  _Ptr<struct _Heap>  parent;
+  _Ptr<struct _Heap>  child;
+  _Ptr<struct _Heap>  forward;
+  _Ptr<struct _Heap>  backward;
   int           rank;
   short         marked;
 } HeapP;
@@ -92,7 +92,7 @@ void  InitFHeap();
  * Return values:
  *   a heap, to be precise an empty, i.e. NULL_HEAP
  */
-HeapP * MakeHeap();
+_Ptr<HeapP>  MakeHeap(void);
 
 /*
  * Find the item with lowest key.
@@ -107,7 +107,7 @@ HeapP * MakeHeap();
  *   an item if the heap is not empty
  *   NULL_ITEM otherwise
  */
-Item * FindMin(HeapP * h);
+_Ptr<Item>  FindMin(_Ptr<HeapP>  h);
 
 /*
  * Insert an item in a heap.
@@ -123,7 +123,7 @@ Item * FindMin(HeapP * h);
  *   a handle to the inserted item, useful in connection with Delete()
  *   and DecreaseKey().
  */
-HeapP * Insert(HeapP * * h, Item * i);
+_Ptr<HeapP>  Insert(_Ptr<_Ptr<HeapP>>  h, _Ptr<Item>  i);
 
 /*
  * Meld to heaps.
@@ -137,7 +137,7 @@ HeapP * Insert(HeapP * * h, Item * i);
  * Return values:
  *   a bigger heap, possibly NULL_HEAP
  */
-HeapP * Meld(HeapP * h1, HeapP * h2);
+_Ptr<HeapP>  Meld(_Ptr<HeapP>  h1, _Ptr<HeapP>  h2);
 
 /*
  * Remove the smallest item in a heap
@@ -151,7 +151,7 @@ HeapP * Meld(HeapP * h1, HeapP * h2);
  * Return values:
  *   a smaller heap, possibly NULL_HEAP
  */
-HeapP * DeleteMin(HeapP * h);
+_Ptr<HeapP>  DeleteMin(_Ptr<HeapP>  h);
 
 /*
  * Decrease the key of an item in a heap.
@@ -169,7 +169,7 @@ HeapP * DeleteMin(HeapP * h);
  * Return values:
  *   a heap, possibly NULL_HEAP
  */
-HeapP * DecreaseKey(HeapP * h, HeapP * i, int delta);
+_Ptr<HeapP>  DecreaseKey(_Ptr<HeapP>  h, _Ptr<HeapP>  i, int delta);
 
 /*
  * Delete an entry in a heap.
@@ -185,7 +185,7 @@ HeapP * DecreaseKey(HeapP * h, HeapP * i, int delta);
  * Return values:
  *   a smaller heap, possibly NULL_HEAP
  */
-HeapP * Delete(HeapP * h, HeapP * i);
+_Ptr<HeapP>  Delete(_Ptr<HeapP>  h, _Ptr<HeapP>  i);
 
 /*
  * Search for an item with a particular key in a heap.
@@ -202,7 +202,7 @@ HeapP * Delete(HeapP * h, HeapP * i);
  * Return values:
  *   an handle to the item, possibly NULL_HEAP
  */
-HeapP * Find(HeapP * h, Item * item);
+_Ptr<HeapP>  Find(_Ptr<HeapP>  h, _Ptr<Item>  item);
 
 /*
  * Converts a item handle into an item pointer.
@@ -216,6 +216,6 @@ HeapP * Find(HeapP * h, Item * item);
  * Return values:
  *   an pointer to the item
  */
-Item * ItemOf(HeapP * h);
+_Ptr<Item>  ItemOf(_Ptr<HeapP>  h);
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
@@ -28,7 +28,8 @@
  *
  */
 
-#include <stdio.h>
+// CHECKEDC
+#include <stdio_checked.h>
 #include "Fheap.h"
 #include "Fstruct.h"
 

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
@@ -33,9 +33,10 @@
 #include "Fstruct.h"
 
 int
-SanityCheck1(HeapP * h, Item * i)
+SanityCheck1(_Ptr<HeapP>  h, _Ptr<Item>  i)
 {
-  HeapP * h1;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
 
   if(h == NULL_HEAP)
   {
@@ -62,11 +63,12 @@ SanityCheck1(HeapP * h, Item * i)
 }
 
 int
-SanityCheck2(HeapP * h)
+SanityCheck2(_Ptr<HeapP>  h)
 {
   int   sum;
-  HeapP * h1;
-  HeapP * h2;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
+  _Ptr<HeapP>  h2 = 0;
 
   if(h == NULL_HEAP)
   {
@@ -106,11 +108,12 @@ SanityCheck2(HeapP * h)
 }
 
 int
-SanityCheck3(HeapP * h, int rank)
+SanityCheck3(_Ptr<HeapP>  h, int rank)
 {
   int   sum;
-  HeapP * h1;
-  HeapP * h2;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
+  _Ptr<HeapP>  h2 = 0;
 
   if((h == NULL_HEAP) && (rank == 0))
   {
@@ -143,9 +146,10 @@ SanityCheck3(HeapP * h, int rank)
 }
 
 void
-PrettyPrint(HeapP * h)
+PrettyPrint(_Ptr<HeapP>  h)
 {
-  HeapP * h1;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  h1 = 0;
 
   if(h == NULL_HEAP)
   {

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.h
@@ -47,7 +47,7 @@
  *   FALSE:	check failed
  *   TRUE:	check succeeded
  */
-int  SanityCheck1(Heap * h, Item * i);
+int  SanityCheck1(_Ptr<Heap> h, _Ptr<Item> i);
 
 /*
  * Check the rank fields in the structure.
@@ -62,7 +62,7 @@ int  SanityCheck1(Heap * h, Item * i);
  *   FALSE:	check failed
  *   TRUE:	check succeeded
  */
-int  SanityCheck2(Heap * h);
+int  SanityCheck2(_Ptr<Heap> h);
 
 /*
  * Check the rank fields in the structure.
@@ -80,7 +80,7 @@ int  SanityCheck2(Heap * h);
  *   FALSE:	check failed
  *   TRUE:	check succeeded
  */
-int  SanityCheck3(Heap * h, int rank);
+int  SanityCheck3(_Ptr<Heap> h, int rank);
 
 /*
  * Print the structure in some human readable form.  It is printed in a
@@ -96,6 +96,6 @@ int  SanityCheck3(Heap * h, int rank);
  * Return values:
  *   none
  */
-void PrettyPrint(Heap * h);
+void PrettyPrint(_Ptr<Heap> h);
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/ft.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/ft.c
@@ -35,8 +35,9 @@
  */
 
 #include <limits.h>
-#include <stdio.h>
-#include <stdlib.h>
+// CHECKEDC
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include <assert.h>
 
 #include <sys/time.h>

--- a/MultiSource/Benchmarks/Ptrdist/ft/ft.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/ft.c
@@ -57,8 +57,8 @@
 /*
  * Local functions.
  */
-void      PrintMST(Vertices * graph);
-Vertices * MST(Vertices * graph);
+void      PrintMST(_Ptr<Vertices>  graph);
+_Ptr<Vertices>  MST(_Ptr<Vertices>  graph);
 
 /*
  * Local variables.
@@ -66,24 +66,25 @@ Vertices * MST(Vertices * graph);
 int debug = 1;
 
 int
-main(int argc, char *argv[])
+main(int argc, _Array_ptr<_Ptr<char>> argv )
 {
   int            nVertex;
   int            nEdge;
-  Vertices *  graph;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>   graph = 0;
 
   nVertex = DEFAULT_N_VERTEX;
   nEdge = DEFAULT_N_EDGE;
 
   if(argc > 1)
   {
-    nVertex = atoi(argv[1]);
+    nVertex = atoi((const char*)argv[1]);
     if(argc > 2)
     {
-      nEdge = atoi(argv[2]);
+      nEdge = atoi((const char*)argv[2]);
       if(argc > 3)
       {
-        srandom(atoi(argv[3]));
+        srandom(atoi((const char*)argv[3]));
       }
     }
   }
@@ -122,12 +123,13 @@ main(int argc, char *argv[])
   return 0;
 }
 
-Vertices *
-MST(Vertices * graph)
+_Ptr<Vertices> 
+MST(_Ptr<Vertices>  graph)
 {
-  HeapP * heap;
-  Vertices * vertex;
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<HeapP>  heap = 0;
+  _Ptr<Vertices>  vertex = 0;
+  _Ptr<Edges>  edge = 0;
   ;
 
   InitFHeap();
@@ -175,9 +177,10 @@ MST(Vertices * graph)
 }
 
 void
-PrintMST(Vertices * graph)
+PrintMST(_Ptr<Vertices>  graph)
 {
-  Vertices * vertex;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  vertex = 0;
 
   assert(graph != NULL_VERTEX);
 

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.c
@@ -50,14 +50,14 @@ static int generatedEdges;
 /*
  * Local functions.
  */
-Vertices * GenTree(int vertex);
-Vertices * AddEdges(Vertices * graph, int nVertex, int nEdge);
-Vertices * PickVertex(Vertices * graph, int whichVertex);
-void      Connect(Vertices * vertex1, Vertices * vertex2);
-int       Duplicate(Vertices * vertex1, Vertices * vertex2);
-Vertices * NewVertex();
-Edges * NewEdge();
-void      PrintNeighbors(Vertices * vertex);
+_Ptr<Vertices>  GenTree(int vertex);
+_Ptr<Vertices>  AddEdges(_Ptr<Vertices>  graph, int nVertex, int nEdge);
+_Ptr<Vertices>  PickVertex(_Ptr<Vertices>  graph, int whichVertex);
+void      Connect(_Ptr<Vertices>  vertex1, _Ptr<Vertices>  vertex2);
+int       Duplicate(_Ptr<Vertices>  vertex1, _Ptr<Vertices>  vertex2);
+_Ptr<Vertices>  NewVertex(void);
+_Ptr<Edges>  NewEdge(void);
+void      PrintNeighbors(_Ptr<Vertices>  vertex);
 
 /*
  * Local variables.
@@ -71,10 +71,11 @@ static id = 1;
  * Apparently a good reference is Tinhofer G., ,
  * C. Hanser, Verlag, M\"{u}nchen 1980.
  */
-Vertices *
+_Ptr<Vertices> 
 GenGraph(int nVertex, int nEdge)
 {
-  Vertices * graph;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  graph = 0;
 
   assert(nEdge + 1 >= nVertex);
   assert(nEdge <= nVertex * (nVertex - 1) / 2);
@@ -86,14 +87,15 @@ GenGraph(int nVertex, int nEdge)
   return(graph);
 }
 
-Vertices *
+_Ptr<Vertices> 
 GenTree(int nVertex)
 {
   int       i;
   int       weight;
-  Vertices * vertex;
-  Vertices * graph;
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  vertex = 0;
+  _Ptr<Vertices>  graph = 0;
+  _Ptr<Edges>  edge = 0;
 
   graph = NewVertex();
   NEXT_VERTEX(graph) = graph;
@@ -137,12 +139,13 @@ GenTree(int nVertex)
   return(graph);
 }
 
-Vertices *
-AddEdges(Vertices * graph, int nVertex, int nEdge)
+_Ptr<Vertices> 
+AddEdges(_Ptr<Vertices>  graph, int nVertex, int nEdge)
 {
   int       i;
-  Vertices * vertex1;
-  Vertices * vertex2;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  vertex1 = 0;
+  _Ptr<Vertices>  vertex2 = 0;
 
   assert(graph != NULL_VERTEX);
   assert(nEdge >= 0);
@@ -163,8 +166,8 @@ AddEdges(Vertices * graph, int nVertex, int nEdge)
   return(graph);
 }
 
-Vertices *
-PickVertex(Vertices * graph, int whichVertex)
+_Ptr<Vertices> 
+PickVertex(_Ptr<Vertices>  graph, int whichVertex)
 {
   int       i;
 
@@ -177,10 +180,11 @@ PickVertex(Vertices * graph, int whichVertex)
 }
 
 void
-Connect(Vertices * vertex1, Vertices * vertex2)
+Connect(_Ptr<Vertices>  vertex1, _Ptr<Vertices>  vertex2)
 {
   int    weight;
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Edges>  edge = 0;
 
   weight = GET_WEIGHT;
 
@@ -200,9 +204,10 @@ Connect(Vertices * vertex1, Vertices * vertex2)
 }
 
 int
-Duplicate(Vertices * vertex1, Vertices * vertex2)
+Duplicate(_Ptr<Vertices>  vertex1, _Ptr<Vertices>  vertex2)
 {
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Edges>  edge = 0;
 
   edge = EDGES(vertex1);
 
@@ -219,12 +224,13 @@ Duplicate(Vertices * vertex1, Vertices * vertex2)
   return(FALSE);
 }
 
-Vertices *
-NewVertex()
+_Ptr<Vertices> 
+NewVertex(void)
 {
-  Vertices * vertex;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  vertex = 0;
 
-  vertex = (Vertices *)malloc(sizeof(Vertices));
+  vertex = malloc(sizeof(Vertices));
 
   if(vertex == NULL)
   {
@@ -239,12 +245,13 @@ NewVertex()
   return(vertex);
 }
 
-Edges *
-NewEdge()
+_Ptr<Edges> 
+NewEdge(void)
 {
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Edges>  edge = 0;
 
-  edge = (Edges *)malloc(sizeof(Edges));
+  edge = malloc(sizeof(Edges));
 
   if(edge == NULL)
   {
@@ -260,9 +267,10 @@ NewEdge()
 }
 
 void
-PrintGraph(Vertices * graph)
+PrintGraph(_Ptr<Vertices>  graph)
 {
-  Vertices * vertex;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Vertices>  vertex = 0;
 
   assert(graph != NULL);
 
@@ -278,9 +286,10 @@ PrintGraph(Vertices * graph)
 }
 
 void
-PrintNeighbors(Vertices * vertex)
+PrintNeighbors(_Ptr<Vertices>  vertex)
 {
-  Edges * edge;
+    // CHECKEDC : automatic variable initialize required
+  _Ptr<Edges>  edge = 0;
 
   edge = EDGES(vertex);
   while(edge != NULL)

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.c
@@ -29,8 +29,9 @@
  */
 
 #include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
+// CHECKEDC
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include "graph.h"
 
 #define TRUE 1

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.h
@@ -37,22 +37,22 @@ typedef struct _Edges
 {
   int               weight;
 
-  struct _Vertices * source;
-  struct _Vertices * vertex;
-  struct _Edges * next;
+  _Ptr<struct _Vertices>  source;
+  _Ptr<struct _Vertices>  vertex;
+  _Ptr<struct _Edges>  next;
 } Edges;
 
 typedef struct _Vertices
 {
   int               id;
-  Edges * edges;
-  struct _Vertices * next;
+  _Ptr<Edges>  edges;
+  _Ptr<struct _Vertices>  next;
 
   /*
    * For the ft algorithm.
    */
   int               key;
-  Edges * chosenEdge;
+  _Ptr<Edges>  chosenEdge;
 } Vertices;
 
 #define NULL_EDGE	((void *) 0)
@@ -72,7 +72,7 @@ typedef struct _Vertices
 #define KEY(V)		((*(V)).key)
 #define CHOSEN_EDGE(V)	((*(V)).chosenEdge)
 
-Vertices * GenGraph(int nVertex, int nEdge);
-void      PrintGraph(Vertices * graph);
+_Ptr<Vertices>  GenGraph(int nVertex, int nEdge);
+void      PrintGraph(_Ptr<Vertices>  graph);
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/item.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/item.c
@@ -34,17 +34,17 @@
 
 #include "item.h"
 
-int LessThan(Item * item1, Item * item2)
+int LessThan(_Ptr<Item>  item1, _Ptr<Item>  item2)
 {
   return(KEY(item1) < KEY(item2));
 }
 
-int Equal(Item * item1, Item * item2)
+int Equal(_Ptr<Item>  item1, _Ptr<Item>  item2)
 {
   return(KEY(item1) == KEY(item2));
 }
 
-Item * Subtract(Item * item, int delta)
+_Ptr<Item>  Subtract(_Ptr<Item>  item, int delta)
 {
     assert(delta > 0);
 

--- a/MultiSource/Benchmarks/Ptrdist/ft/item.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/item.c
@@ -28,8 +28,9 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+// CHECKEDC : checked header include
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include <assert.h>
 
 #include "item.h"

--- a/MultiSource/Benchmarks/Ptrdist/ft/item.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/item.h
@@ -37,8 +37,8 @@ typedef Vertices Item;
 
 #define NULL_ITEM	NULL_VERTEX
 
-int LessThan(Item *, Item *);
-int Equal(Item *, Item *);
-Item * Subtract(Item *, int);
+int LessThan(_Ptr<Item> , _Ptr<Item> );
+int Equal(_Ptr<Item> , _Ptr<Item> );
+_Ptr<Item>  Subtract(_Ptr<Item> , int);
 
 #endif

--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -1,0 +1,16 @@
+//--------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in fenv.h that                //
+// take pointer arguments.                                            //
+//                                                                    //
+// These are listed in the same order that they occur in the C11      //
+// specification.                                                     //
+////////////////////////////////////////////////////////////////////////
+
+#include <fenv.h>
+
+int fesetexceptflag(const fexcept_t *flagp : itype(_Ptr<const fexcept_t>),
+                    int excepts);
+int fegetenv(fenv_t *envp : itype(_Ptr<fenv_t>));
+int feholdexcept(fenv_t *envp : itype(_Ptr<fenv_t>));
+int fesetenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
+int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in inttypes.h that             //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
+#include <inttypes.h>
+
+intmax_t strtoimax(const char * restrict nptr,
+                   char ** restrict endptr : itype(restrict _Ptr<char *>),
+                   int base);
+uintmax_t strtoumax(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>),
+                    int base);
+
+intmax_t wcstoimax(const wchar_t * restrict nptr,
+                   wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                   int base);
+uintmax_t wcstoumax(const wchar_t * restrict nptr,
+                    wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                    int base);

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -1,0 +1,30 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <math.h>
+
+double frexp(double value, int *exp : itype(_Ptr<int>));
+float frexpf(float value, int *exp : itype(_Ptr<int>));
+long double frexpl(long double value, int *exp : itype(_Ptr<int>));
+
+double modf(double value, double *iptr : itype(_Ptr<double>));
+float modff(float value, float *iptr : itype(_Ptr<float>));
+long double modfl(long double value,
+                  long double *iptr : itype(_Ptr<long double>));
+
+double remquo(double x, double y, int *quo : itype(_Ptr<int>));
+float remquof(float x, float y, int *quo : itype(_Ptr<int>));
+long double remquol(long double x, long double y, int *quo : itype(_Ptr<int>));
+
+// TODO: strings
+// double nan(const char *t);
+// float nanf(const char *t);
+// long double nanf(const char *t);

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -1,0 +1,12 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for a functions in signal.h that             //
+// take pointer arguments.                                             //
+/////////////////////////////////////////////////////////////////////////
+
+#include <signal.h>
+
+void (*signal(int sig,
+              void ((*func)(int)) :
+                itype(_Ptr<void (int)>) // bound-safe interface for func
+              ) : itype(_Ptr<void (int)>) // bounds-safe interface for signal return
+     )(int);

--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -1,0 +1,11 @@
+#ifndef __STDCHECKED_H
+#define __STDCHECKED_H
+
+#define ptr _Ptr
+#define array_ptr _Array_ptr
+#define checked _Checked
+#define unchecked _Unchecked
+#define where _Where
+#define dynamic_check _Dynamic_check
+
+#endif /* __STDCHECKED_H */

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -1,0 +1,122 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+
+// TODO: handle strings
+// int remove(const char *name);
+// int rename(const char *from, const char *to);
+FILE *tmpfile(void) : itype(_Ptr<FILE>);
+// TODO: handle strings
+// char *tmpnam(char *source);
+int fclose(FILE *stream : itype(_Ptr<FILE>));
+int fflush(FILE *stream : itype(_Ptr<FILE>));
+FILE *fopen(const char * restrict filename,
+            const char * restrict mode) : itype(_Ptr<FILE>);
+FILE *freopen(const char * restrict filename,
+              const char * restrict mode,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  itype(_Ptr<FILE>);
+
+void setbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(BUFSIZ));
+int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(size),
+            int mode, size_t size);
+
+//
+// TODO: printing and scanning functions are still mostly
+// unchecked because of the use of varargs.
+// * There may not be enough arguments for the format string.
+// * Any pointer arguments may not meet the requirements of the
+//  format string.
+//
+int fprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format, ...);
+int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+           const char * restrict format, ...);
+// TODO: handle strings
+// int printf(const char * restrict format, ...);
+// int scanf(const char * restrict format, ...);
+
+// OMITTED INTENTIONALLY:
+// sprintf cannot be made checked.  It is missing the bounds
+// for the output buffer.
+// int sprintf(char * restrict s,
+//            const char * restrict format, ...);
+//
+// TODO: handle strings
+// int sscanf(const char * restrict s,
+//            const char * restrict format, ...);
+int snprintf(char * restrict s : count(n), size_t n,
+             const char * restrict format, ...);
+
+int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+             const char * restrict format,
+             va_list arg);
+int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format,
+            va_list arg);
+
+// TODO: handle strings
+// int vprintf(const char * restrict format,
+//             va_list arg);
+// int vscanf(const char * restrict format,
+//            va_list arg);
+int vsnprintf(char * restrict s : count(n), size_t n,
+              const char * restrict format,
+              va_list arg);
+// OMITTED INTENTIONALLY:
+// vsprintf cannot be made checked. it is missing the bounds
+// for the output buffer.
+// int vsprintf(char * restrict s,
+//             const char * restrict format,
+//             va_list arg);
+// TODO: handle strings
+// int vsscanf(const char * restrict s,
+//            const char * restrict format,
+//            va_list arg);
+
+int fgetc(FILE *stream : itype(_Ptr<FILE>));
+char *fgets(char * restrict s : count(n), int n,
+            FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  bounds(s, s + n);
+int fputs(const char * restrict s,
+          FILE * restrict stream : itype(restrict _Ptr<FILE>));
+int getc(FILE *stream : itype(_Ptr<FILE>));
+int putc(int c, FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// int puts(const char *str);
+int ungetc(int c, FILE *stream : itype(_Ptr<FILE>));
+
+size_t fread(void * restrict ptr : byte_count(size * nmemb),
+             size_t size, size_t nmemb,
+             FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+size_t fwrite(const void * restrict ptr : byte_count(size * nmemb),
+              size_t size, size_t nmemb,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+int fgetpos(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            fpos_t * restrict pos : itype(restrict _Ptr<fpos_t>));
+
+int fseek(FILE *stream : itype(_Ptr<FILE>), long int offset, int whence);
+int fsetpos(FILE *stream : itype(_Ptr<FILE>),
+            const fpos_t *pos :  itype(_Ptr<const fpos_t>));
+
+long int ftell(FILE *stream : itype(_Ptr<FILE>));
+void rewind(FILE *stream : itype(_Ptr<FILE>));
+
+void clearerr(FILE *stream : itype(_Ptr<FILE>));
+int feof(FILE *stream : itype(_Ptr<FILE>));
+int ferror(FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// void perror(const char *s);

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -1,0 +1,94 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in stdlib.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+#include <stdlib.h>
+
+// TODO: strings
+// double atof(const char *s);
+// int atoi(const char *s);
+// long int atol(const char *s);
+// long long int atoll(const char *s);
+
+double strtod(const char * restrict nptr,
+              char ** restrict endptr : itype(restrict _Ptr<char *>));
+float strtof(const char * restrict nptr,
+             char ** restrict endptr : itype(restrict _Ptr<char *>));
+long double strtold(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>));
+
+long int strtol(const char * restrict nptr,
+                char ** restrict endptr : itype(restrict _Ptr<char *>),
+                int base);
+long long int strtoll(const char * restrict nptr,
+                      char ** restrict endptr : itype(restrict _Ptr<char *>),
+                      int base);
+unsigned long int strtoul(const char * restrict nptr,
+                          char ** restrict endptr :
+                            itype(restrict _Ptr<char *>),
+                          int base);
+
+unsigned long long int strtoull(const char * restrict nptr,
+                                char ** restrict endptr:
+                                   itype(restrict _Ptr<char *>),
+                                int base);
+
+// TODO: express alignment constraints once where clauses have been added.
+void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
+void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
+void free(void *ptr : itype(_Ptr<void>));
+void *malloc(size_t size) : byte_count(size);
+void *realloc(void *ptr  : itype(_Ptr<void>), size_t size) : byte_count(size);
+
+// TODO: strings
+// char *getenv(const char *n);
+
+int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
+int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));
+
+// TODO: strings
+// int system(const char *s);
+
+// TODO: compar needs to have an itype that has bounds
+// on parameters based on size.  Currently we are requiring that
+// bounds in parameters lists be closed with respect to variables
+// in the parameter list.
+void *bsearch(const void *key : byte_count(size),
+              const void *base : byte_count(nmemb * size),
+              size_t nmemb, size_t size,
+              int ((*compar)(const void *, const void *)) :
+                itype(_Ptr<int(_Ptr<const void>, _Ptr<const void>)>)) :
+                byte_count(size);
+
+// TODO: compar needs to have an itype that has bounds
+// on parameters based on size.  Currently we are requiring that
+// types be closed.
+void qsort(void *base : byte_count(nmemb * size),
+           size_t nmemb, size_t size,
+           int ((*compar)(const void *, const void *)) :
+             itype(_Ptr<int (_Ptr<const void>, _Ptr<const void>)>));
+
+int mblen(const char *s : count(n), size_t n);
+
+int mbtowc(wchar_t * restrict output : itype(restrict _Ptr<wchar_t>),
+           const char * restrict input : count(n),
+           size_t n);
+
+// MB_CUR_MAX is a macro that becomes a function call, so is banned
+// in bounds annotations. 
+// 
+// int wctomb(char *s : count(MB_CUR_MAX), wchar_t wc);
+
+size_t mbstowcs(wchar_t * restrict pwcs : count(n),
+                const char * restrict s,
+                size_t n);
+
+size_t wcstombs(char * restrict output : count(n),
+                const wchar_t * restrict pwcs,
+                size_t n);

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -1,0 +1,71 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in string.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+#include <string.h>
+
+void *memcpy(void * restrict dest : byte_count(n),
+             const void * restrict src : byte_count(n),
+             size_t n) : bounds(dest, (char *) dest + n);
+
+void *memmove(void * restrict dest : byte_count(n),
+              const void * restrict src : byte_count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+// TODO: strings
+// char *strcpy(char * restrict dest,
+//              const char * restrict src);
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on s1.
+// char *strcpy(char * restrict s1,
+//              const char * restrict s2);
+char *strncpy(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on dest.
+// char *strcat(char * restrict dest,
+//              const char * restrict src);
+
+char *strncat(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+
+int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
+           size_t n);
+
+// TODO: strings
+// int strcmp(const char *src1, const char *src2);
+// int strcoll(const char *src1, const char *src2);
+
+//int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
+size_t strxfrm(char * restrict dest : count(n),
+               const char * restrict src,
+               size_t n);
+
+void *memchr(const void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char *) s + n);
+
+// TODO: strings
+// char *strchr(const char *s, int c);
+// size_t strcspn(const char *s1, const char *s2);
+// char *strpbrk(const char *s1, const char *s2);
+// char *strrchr(const char *s, int c);
+// size_t strspn(const char *s1, const char *s2);
+// char *strstr(const char *s1, const char *s2);
+// char *strtok(char * restrict s1,
+//              const char * restrict s2);
+
+void *memset(void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char *) s + n);
+
+// TODO: strings
+// char *strerror(int errnum);
+// size_t strlen(const char *s);

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in threads.h that              //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+/////////////////////////////////////////////////////////////////////////
+
+#ifdef _CHECKEDC_MOCKUP_THREADS
+// C implementations may not support the C11 threads package or even the
+// macro that says C11 threads are not supported.  This mocks up
+// the types needed by threads so that we can test that the declarations
+// below compile.
+typedef struct __once_flag_struct once_flag;
+typedef struct __cnd_struct cnd_t;
+typedef struct __mtx_struct mtx_t;
+typedef struct __thread_struct thrd_t;
+typedef int (*thrd_start_t)(void *);
+typedef struct __thread_specific_storage_struct tss_t;
+typedef void (tss_dtor_t)(void *);
+struct timespec;
+#else
+#include <threads.h>
+#endif
+
+void call_once(once_flag *flag : itype(_Ptr<once_flag>),
+               void ((*fn)(void)) : itype(_Ptr<void (void)>));
+
+int cnd_broadcast(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_destroy(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_init(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_signal(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_timedwait(cnd_t *restrict cond : itype(restrict _Ptr<cnd_t>),
+                  mtx_t *restrict mutex: itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict spec :
+                    itype(restrict _Ptr<const struct timespec>));
+int cnd_wait(cnd_t *condition : itype(_Ptr<cnd_t>),
+             mtx_t *mutex : itype(_Ptr<mtx_t>));
+void mtx_destroy(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_init(mtx_t *mutex : itype(_Ptr<mtx_t>), int type);
+int mtx_lock(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_timedlock(mtx_t *restrict mutex : itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict ts :
+                    itype(restrict _Ptr<const struct timespec>));
+int mtx_trylock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+int mtx_unlock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+
+int thrd_create(thrd_t *thr : itype(_Ptr<thrd_t>),
+                thrd_start_t func :
+                  itype(_Ptr<int (void * : itype(_Ptr<void>))>),
+                void *arg : itype(_Ptr<void>));
+int thrd_join(thrd_t thr, int *res : itype(_Ptr<int>));
+int thrd_sleep(const struct timespec *duration :
+                 itype(_Ptr<const struct timespec>),
+               struct timespec *remaining : itype(_Ptr<struct timespec>));
+int tss_create(tss_t *key : itype(_Ptr<tss_t>),
+               tss_dtor_t dtor :
+                 itype(_Ptr<void (void * : itype(_Ptr<void>))>));
+// Casting the Ptr<void> returned by tss_get to a specific type will be an
+// unchecked operation.
+void *tss_get(tss_t key) : itype(_Ptr<void>);
+int tss_set(tss_t key, void *value : itype(_Ptr<void>));

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in time.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <time.h>
+
+time_t mktime(struct tm *timeptr : itype(_Ptr<struct tm>));
+int timespec_get(struct timespec *ts : itype(_Ptr<struct timespec>),
+                 int base);
+char *asctime(const struct tm *timeptr : itype(_Ptr<const struct tm>));
+char *ctime(const time_t *timer : itype(_Ptr<const time_t>));
+struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+size_t strftime(char * restrict output : count(maxsize),
+                size_t maxsize,
+                const char * restrict format,
+                const struct tm * restrict timeptr :
+                   itype(restrict _Ptr<const struct tm>));
+
+


### PR DESCRIPTION
- First conversion for applications in Ptrdist benchmarks (Ptrdist/anagram)
  - anagram benchmark exploits pointer intensively to handle input string
  - it reads input file, makes dictionary, extract some phrase and builds new words
  - CheckedC feature lists touched by conversion
    - CheckedC _Ptr used
    - CheckedC _Array_ptr used
      - bounds(start, end) used
      - count(length) used
    - CheckedC _Checked array type used
      - checked array type of T == checked array pointer to T
    - CheckedC function call
      - formal parameter bounds information
      - return value bounds information
    - CheckedC pointer arithmetic - assume that dynamic bounds check will be inserted
    - CheckedC pointer dereference - assume that dynamic bounds check will be inserted
    - CheckedC structure member variable bounds declaration
  - CheckedC feature lists not touched by conversion
    - CheckedC _Where syntax is necessary but not used
      - bounds definition at expression statement but not compiled
    - bounds-safe interface is not yet
  - Conversion status(result)
    - LNT (LLVM Nightly Tests) framework passed
      - compilation passed - clang compilation with "--cflags -fcheckedc-extension" arguments
      - execution passed (identical result to pure C code)
  - What is done for conversion
    - unchecked pointer type to checked pointer type (_Array_ptr, _Ptr)
    - add bounds information for checked array pointer type
    - add qualifier _Checked for checked array type
    - add specific comment pattern to represent code modification
      - refer to comment (// CHECKEDC) to understand meaning of checkedc pointer types in converted source
      - Also expects runtime bounds check which will be inserted by compiler
      - To represent out-of-bounds check, imagine runtime bounds check insertion by compiler