### PR TITLE
Adds include dir for checked headers to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   )
 
+set(LLVM_TEST_SUITE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Sanity check our source directory to make sure that we are not trying to
 # generate an in-tree build (unless on MSVC_IDE, where it is ok), and to make
 # sure that we don't have any stray generated files lying around in the tree
@@ -185,7 +187,8 @@ if(NOT TEST_SUITE_SUBDIRS)
     get_filename_component(subdir ${entry} DIRECTORY)
     # Exclude tools and CTMark from default list
     if(NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/tools AND
-       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/CTMark)
+       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/CTMark AND
+       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/include)
       list(APPEND TEST_SUITE_SUBDIRS ${subdir})
     endif()
   endforeach()

--- a/cmake/modules/SingleMultiSource.cmake
+++ b/cmake/modules/SingleMultiSource.cmake
@@ -190,7 +190,7 @@ macro(llvm_multisource)
     set(_target ${_LMARG_PREFIX}${PROG})
     llvm_test_executable(${_target} ${sources})
     target_include_directories(${_target}
-      PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+      PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} "${LLVM_TEST_SUITE_DIR}/include")
     if(_LMARG_TARGET_VAR)
       set(${_LMARG_TARGET_VAR} ${_target})
     endif()


### PR DESCRIPTION
The build was broken with `lnt runtests test_suite ...` (which uses CMake underneath). I thought it sensible to fix it so that it matches the Makefile version (`lnt runtests nt ...`).

I don't understand how the Makefile version picks up it needs to add the include dir to the include path, which I'm going to go ahead and assume is part of the implicit rules Make has built in.