### PR TITLE
Benchmark Conversion of Olden/bisort

### DIFF
--- a/MultiSource/Benchmarks/Olden/bisort/args.c
+++ b/MultiSource/Benchmarks/Olden/bisort/args.c
@@ -1,5 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 #include <stdlib.h>
+#include <stdchecked.h>
+#include <stdlib_checked.h>
 
 extern int NumNodes,NDim;
 extern int flag;
@@ -11,7 +13,7 @@ int mylog(int num) {
   return j;
 } 
 
-int dealwithargs(int argc, _Array_ptr<char*> argv : count(argc))
+int dealwithargs(int argc, array_ptr<char*> argv : count(argc))
 {
   int size;
 

--- a/MultiSource/Benchmarks/Olden/bisort/args.c
+++ b/MultiSource/Benchmarks/Olden/bisort/args.c
@@ -11,7 +11,7 @@ int mylog(int num) {
   return j;
 } 
 
-int dealwithargs(int argc, char *argv[])
+int dealwithargs(int argc, _Array_ptr<char*> argv : count(argc))
 {
   int size;
 

--- a/MultiSource/Benchmarks/Olden/bisort/bitonic.c
+++ b/MultiSource/Benchmarks/Olden/bisort/bitonic.c
@@ -6,6 +6,10 @@
 #include "proc.h"   /* Procedure Types/Nums */
 #include <stdio.h>
 
+#include <stdio_checked.h>
+// Has to come after stdio_checked.h, as fread uses ptr as an argument name.
+#include <stdchecked.h>
+
 #define CONST_m1 10000
 #define CONST_b 31415821
 #define RANGE 100
@@ -18,7 +22,7 @@ int flag=0,foo=0;
 
 #define LocalNewNode(h,v) \
 { \
-    h = (HANDLE *) malloc(sizeof(struct node)); \
+    h = (ptr<HANDLE>) malloc(sizeof(struct node)); \
       h->value = v; \
 	h->left = NIL; \
 	  h->right = NIL; \
@@ -26,8 +30,8 @@ int flag=0,foo=0;
 
 #define NewNode(h,v,procid) LocalNewNode(h,v)
 
-void InOrder(HANDLE *h) {
-  HANDLE *l, *r;
+void InOrder(ptr<HANDLE> h) {
+  ptr<HANDLE> l = NIL, r = NIL;
   if ((h != NIL)) {
     l = h->left;
     r = h->right;
@@ -57,10 +61,10 @@ int random(int seed) {
   return mult(seed,CONST_b)+1;
 }
 
-HANDLE* RandTree(int n, int seed, int node, int level) {
+ptr<HANDLE> RandTree(int n, int seed, int node, int level) {
   int next_val,my_name;
   future_cell_int f_left, f_right;
-  HANDLE *h;
+  ptr<HANDLE> h = NIL;
   my_name=foo++;
   if (n > 1) {
     int newnode;
@@ -82,7 +86,7 @@ HANDLE* RandTree(int n, int seed, int node, int level) {
   return h;
 }
 
-void SwapValue(HANDLE *l, HANDLE *r) {
+void SwapValue(ptr<HANDLE> l, ptr<HANDLE> r) {
   int temp,temp2;
   
   temp = l->value;
@@ -95,10 +99,10 @@ void
 /***********/
 SwapValLeft(l,r,ll,rl,lval,rval)
 /***********/
-HANDLE *l;
-HANDLE *r;
-HANDLE *ll;
-HANDLE *rl;
+ptr<HANDLE> l;
+ptr<HANDLE> r;
+ptr<HANDLE> ll;
+ptr<HANDLE> rl;
 int lval, rval;
 {
   r->value = lval;
@@ -112,10 +116,10 @@ void
 /************/
 SwapValRight(l,r,lr,rr,lval,rval)
 /************/
-HANDLE *l;
-HANDLE *r;
-HANDLE *lr;
-HANDLE *rr;
+ptr<HANDLE> l;
+ptr<HANDLE> r;
+ptr<HANDLE> lr;
+ptr<HANDLE> rr;
 int lval, rval;
 {  
   r->value = lval;
@@ -129,15 +133,15 @@ int
 /********************/
 Bimerge(root,spr_val,dir)
 /********************/
-HANDLE *root;
+ptr<HANDLE> root;
 int spr_val,dir;
 
 { int rightexchange;
   int elementexchange;
-  HANDLE *pl,*pll,*plr;
-  HANDLE *pr,*prl,*prr;
-  HANDLE *rl;
-  HANDLE *rr;
+  ptr<HANDLE> pl = NIL, pll = NIL, plr = NIL;
+  ptr<HANDLE> pr = NIL, prl = NIL, prr = NIL;
+  ptr<HANDLE> rl = NIL;
+  ptr<HANDLE> rr = NIL;
   int rv,lv;
 
 
@@ -204,11 +208,11 @@ int
 /*******************/
 Bisort(root,spr_val,dir)
 /*******************/
-HANDLE *root;
+ptr<HANDLE> root;
 int spr_val,dir;
 
-{ HANDLE *l;
-  HANDLE *r;
+{ ptr<HANDLE> l = NIL;
+  ptr<HANDLE> r = NIL;
   int val;
   /*printf("bisort %x\n", root);*/
   if ((root->left == NIL))  /* <---- 8.7% load penalty */
@@ -236,8 +240,8 @@ int spr_val,dir;
   return spr_val;
 } 
 
-int main(int argc, char **argv) {
-  HANDLE *h;
+int main(int argc, array_ptr<char*> argv : count(argc)) {
+  ptr<HANDLE> h = NIL;
   int sval;
   int n;
    

--- a/MultiSource/Benchmarks/Olden/bisort/bitonic.c
+++ b/MultiSource/Benchmarks/Olden/bisort/bitonic.c
@@ -4,11 +4,9 @@
 /* UP - 0, DOWN - 1 */
 #include "node.h"   /* Node Definition */
 #include "proc.h"   /* Procedure Types/Nums */
-#include <stdio.h>
-
-#include <stdio_checked.h>
-// Has to come after stdio_checked.h, as fread uses ptr as an argument name.
 #include <stdchecked.h>
+#include <stdio.h>
+#include <stdio_checked.h>
 
 #define CONST_m1 10000
 #define CONST_b 31415821

--- a/MultiSource/Benchmarks/Olden/bisort/bitonic.c
+++ b/MultiSource/Benchmarks/Olden/bisort/bitonic.c
@@ -86,6 +86,8 @@ ptr<HANDLE> RandTree(int n, int seed, int node, int level) {
   return h;
 }
 
+// CHECKED-C: The only two conversions that checked-c-convert could
+// perform automatically were these two.
 void SwapValue(ptr<HANDLE> l, ptr<HANDLE> r) {
   int temp,temp2;
   

--- a/MultiSource/Benchmarks/Olden/bisort/node.h
+++ b/MultiSource/Benchmarks/Olden/bisort/node.h
@@ -2,18 +2,20 @@
 
 /* =============== NODE STRUCTURE =================== */
 
+#include <stdchecked.h>
+
 struct node { 
   int value;
-  _Ptr<struct node> left;
-  _Ptr<struct node> right;
+  ptr<struct node> left;
+  ptr<struct node> right;
 };
 
 typedef struct node HANDLE;
 
 typedef struct future_cell_int{
-  _Ptr<HANDLE> value;
+  ptr<HANDLE> value;
 } future_cell_int;
 
 extern void *malloc(unsigned);
 
-#define NIL ((_Ptr<HANDLE>) 0)
+#define NIL ((ptr<HANDLE>) 0)

--- a/MultiSource/Benchmarks/Olden/bisort/node.h
+++ b/MultiSource/Benchmarks/Olden/bisort/node.h
@@ -4,16 +4,16 @@
 
 struct node { 
   int value;
-  struct node *left;
-  struct node *right;
+  _Ptr<struct node> left;
+  _Ptr<struct node> right;
 };
 
 typedef struct node HANDLE;
 
 typedef struct future_cell_int{
-  HANDLE *value;
+  _Ptr<HANDLE> value;
 } future_cell_int;
 
 extern void *malloc(unsigned);
 
-#define NIL ((HANDLE *) 0)
+#define NIL ((_Ptr<HANDLE>) 0)

--- a/MultiSource/Benchmarks/Olden/bisort/proc.h
+++ b/MultiSource/Benchmarks/Olden/bisort/proc.h
@@ -2,12 +2,13 @@
 
 /* ========== PROCEDURE TYPES/NUMS ================== */
 
+#include <stdchecked.h>
 
-_Ptr<HANDLE> RandTree(int n, int seed, int node, int level);
+ptr<HANDLE> RandTree(int, int, int, int);
 
-void SwapValue(_Ptr<HANDLE>, _Ptr<HANDLE>);
-void SwapValLeft(_Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, int, int);
-void SwapValRight(_Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, int, int);
-int Bimerge(_Ptr<HANDLE>, int, int);
-int Bisort(_Ptr<HANDLE>, int, int);
-int dealwithargs(int argc, _Array_ptr<char*> argv : count(argc));
+void SwapValue(ptr<HANDLE>, ptr<HANDLE>);
+void SwapValLeft(ptr<HANDLE>, ptr<HANDLE>, ptr<HANDLE>, ptr<HANDLE>, int, int);
+void SwapValRight(ptr<HANDLE>, ptr<HANDLE>, ptr<HANDLE>, ptr<HANDLE>, int, int);
+int Bimerge(ptr<HANDLE>, int, int);
+int Bisort(ptr<HANDLE>, int, int);
+int dealwithargs(int argc, array_ptr<char*> argv : count(argc));

--- a/MultiSource/Benchmarks/Olden/bisort/proc.h
+++ b/MultiSource/Benchmarks/Olden/bisort/proc.h
@@ -3,11 +3,11 @@
 /* ========== PROCEDURE TYPES/NUMS ================== */
 
 
-HANDLE *RandTree();
+_Ptr<HANDLE> RandTree(int n, int seed, int node, int level);
 
-void SwapValue();
-void SwapValLeft();
-void SwapValRight();
-int Bimerge();
-int Bisort();
-int dealwithargs(int argc, char *argv[]);
+void SwapValue(_Ptr<HANDLE>, _Ptr<HANDLE>);
+void SwapValLeft(_Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, int, int);
+void SwapValRight(_Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, _Ptr<HANDLE>, int, int);
+int Bimerge(_Ptr<HANDLE>, int, int);
+int Bisort(_Ptr<HANDLE>, int, int);
+int dealwithargs(int argc, _Array_ptr<char*> argv : count(argc));


### PR DESCRIPTION
In this, almost all pointers can be changed to `_Ptr<T>`, except the `_Array_ptr<char*>` in main.

This relies on the fix in #11.

Issues I ran into:
- Getting checked-c-convert working. Involves using the CMake build system with the following options: `CMAKE_EXPORT_COMPILE_COMMANDS=ON` and `TEST_SUITE_TAKE_COMPILE_TIME=OFF` to get a `compile_commands.json` that the converter understands. Even then it only managed to convert two pointers. I'm not sure why, is there an issue with this style of function declaration?
- `stdio_checked.h` defines a parameter called `ptr`, which means it has to be included before `stdchecked.h` - this is definitely something we should fix. I'll file a bug about this in the checkedc repo.

Closes #12 