### PR TITLE
Modifies the Olden/mst Benchmark for Checked C

### DIFF
--- a/MultiSource/Benchmarks/Olden/mst/args.c
+++ b/MultiSource/Benchmarks/Olden/mst/args.c
@@ -1,10 +1,12 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
+
 extern int atoi(const char *);
 
 int NumNodes = 1;
 
-int dealwithargs(int argc, char *argv[]) {
+int dealwithargs(int argc, array_ptr<char*> argv : count(argc)) {
   int level;
 
   if (argc > 1)

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -43,7 +43,8 @@ Hash MakeHash(int size, int (*map)(unsigned int))
 void *HashLookup(unsigned int key, Hash hash)
 {
   int j;
-  HashEntry ent;
+  // CHECKED C: This was converted using checked-c-convert
+  _Ptr<struct hash_entry>  ent;
 
   j = (hash->mapfunc)(key);        /* 14% miss in hash->mapfunc */  
   assert(1,j>=0);
@@ -71,10 +72,13 @@ void HashInsert(void *entry,unsigned int key,Hash hash)
   ent->entry = entry;
 }
 
-void HashDelete(unsigned key, Hash hash) {
-  HashEntry tmp;
+// CHECKED C: This was converted using checked-c-convert
+void HashDelete(unsigned key, _Ptr<struct hash>  hash) {
+  // CHECKED C: This was converted using checked-c-convert
+  _Ptr<struct hash_entry>  tmp;
   int j = (hash->mapfunc)(key);
-  HashEntry *ent = &hash->array[j];
+  // CHECKED C: This was converted using checked-c-convert
+  _Ptr<_Ptr<struct hash_entry>>  ent = &hash->array[j];
 
   while (*ent && (*ent)->key != key) {
     ent = &(*ent)->next;

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -1,6 +1,8 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
 #include <stdlib.h>
+#include <stdlib_checked.h>
 #include "hash.h"
 
 #define assert(num,a) if (!(a)) {printf("Assertion failure:%d in hash\n",num); exit(-1);}
@@ -8,7 +10,7 @@
 static int remaining = 0;
 static char *temp;
 
-static char *localmalloc(int size) 
+static char *localmalloc(int size) : byte_count(size)
 {
   char *blah;
   
@@ -43,7 +45,6 @@ Hash MakeHash(int size, ptr<int(unsigned int)> map)
 void *HashLookup(unsigned int key, Hash hash)
 {
   int j;
-  // CHECKED C: This was converted using checked-c-convert
   HashEntry ent = NULL;
 
   j = (hash->mapfunc)(key);        /* 14% miss in hash->mapfunc */  
@@ -65,20 +66,17 @@ void HashInsert(void *entry,unsigned int key,Hash hash)
   assert(3,!HashLookup(key,hash));
   
   j = (hash->mapfunc)(key);
-  ent = (HashEntry) localmalloc(sizeof(*ent));
+  ent = (HashEntry)localmalloc(sizeof(*ent));
   ent->next = hash->array[j];
   hash->array[j]=ent;
   ent->key = key;
   ent->entry = entry;
 }
 
-// CHECKED C: This was converted using checked-c-convert
 void HashDelete(unsigned key, Hash hash) {
-  // CHECKED C: This was converted using checked-c-convert
   HashEntry tmp = NULL;
   int j = (hash->mapfunc)(key);
-  // CHECKED C: This was converted using checked-c-convert
-  ptr<HashEntry> ent = &hash->array[j];
+  HashEntry *ent = &hash->array[j];
 
   while (*ent && (*ent)->key != key) {
     ent = &(*ent)->next;

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -36,10 +36,11 @@ Hash MakeHash(int size, ptr<int(unsigned int)> map)
 
   retval = (Hash) localmalloc(sizeof(*retval));
   retval->array = (HashEntry *) localmalloc(size*sizeof(HashEntry));
-  for (i=0; i<size; i++)
-    retval->array[i]=NULL;
-  retval->mapfunc = map;
   retval->size = size;
+  // CHECKEC C: Not required, as localmalloc now uses calloc internally
+  // for (i=0; i<size; i++)
+  //   retval->array[i] = NULL;
+  retval->mapfunc = map;
   return retval;
 }
 

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -8,16 +8,17 @@
 #define assert(num,a) if (!(a)) {printf("Assertion failure:%d in hash\n",num); exit(-1);}
 
 static int remaining = 0;
-static char *temp;
+static array_ptr<char> temp : count(remaining);
 
-static char *localmalloc(int size) : byte_count(size)
+static array_ptr<char> localmalloc(int size) : byte_count(size)
 {
-  char *blah;
+  array_ptr<char> blah;
   
   if (size>remaining) 
     {
-      temp = (char *) malloc(32768);
-      if (!temp) printf("Error! malloc returns null\n");
+      temp = (char *) calloc(32768, sizeof(char));
+      dynamic_check(temp != NULL);
+      // if (!temp) printf("Error! malloc returns null\n");
       remaining = 32768;
     }
   blah = temp;

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -26,9 +26,9 @@ static char *localmalloc(int size)
 
 #define localfree(sz)
 
-Hash MakeHash(int size, int (*map)(unsigned int)) 
+Hash MakeHash(int size, ptr<int(unsigned int)> map)
 {
-  Hash retval;
+  Hash retval = NULL;
   int i;
 
   retval = (Hash) localmalloc(sizeof(*retval));
@@ -44,7 +44,7 @@ void *HashLookup(unsigned int key, Hash hash)
 {
   int j;
   // CHECKED C: This was converted using checked-c-convert
-  _Ptr<struct hash_entry>  ent;
+  HashEntry ent = NULL;
 
   j = (hash->mapfunc)(key);        /* 14% miss in hash->mapfunc */  
   assert(1,j>=0);
@@ -59,7 +59,7 @@ void *HashLookup(unsigned int key, Hash hash)
 
 void HashInsert(void *entry,unsigned int key,Hash hash) 
 {
-  HashEntry ent;
+  HashEntry ent = NULL;
   int j;
   
   assert(3,!HashLookup(key,hash));
@@ -73,12 +73,12 @@ void HashInsert(void *entry,unsigned int key,Hash hash)
 }
 
 // CHECKED C: This was converted using checked-c-convert
-void HashDelete(unsigned key, _Ptr<struct hash>  hash) {
+void HashDelete(unsigned key, Hash hash) {
   // CHECKED C: This was converted using checked-c-convert
-  _Ptr<struct hash_entry>  tmp;
+  HashEntry tmp = NULL;
   int j = (hash->mapfunc)(key);
   // CHECKED C: This was converted using checked-c-convert
-  _Ptr<_Ptr<struct hash_entry>>  ent = &hash->array[j];
+  ptr<HashEntry> ent = &hash->array[j];
 
   while (*ent && (*ent)->key != key) {
     ent = &(*ent)->next;

--- a/MultiSource/Benchmarks/Olden/mst/hash.h
+++ b/MultiSource/Benchmarks/Olden/mst/hash.h
@@ -1,20 +1,24 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
 #include "stdio.h"
 
-typedef struct hash_entry {
+struct hash_entry {
   unsigned int key;
   void *entry;
-  struct hash_entry *next;
-} *HashEntry;
+  ptr<struct hash_entry> next;
+};
+typedef ptr<struct hash_entry> HashEntry;
 
-typedef struct hash {
-  HashEntry *array;
-  int (*mapfunc)(unsigned int);
+struct hash {
+  HashEntry *array; // Has count(size) bounds, but this currently errors
+  ptr<int(unsigned int)> mapfunc;
   int size;
-} *Hash;
+};
 
-Hash MakeHash(int size, int (*map)(unsigned int));
+typedef ptr<struct hash> Hash;
+
+Hash MakeHash(int size, ptr<int(unsigned int)> map);
 void *HashLookup(unsigned int key, Hash hash);
-void HashInsert(void *entry,unsigned int key, Hash hash);
+void HashInsert(void *entry, unsigned int key, Hash hash);
 void HashDelete(unsigned int key, Hash hash);

--- a/MultiSource/Benchmarks/Olden/mst/hash.h
+++ b/MultiSource/Benchmarks/Olden/mst/hash.h
@@ -2,16 +2,18 @@
 
 #include <stdchecked.h>
 #include "stdio.h"
+#include <stdio_checked.h>
 
 struct hash_entry {
   unsigned int key;
   void *entry;
   ptr<struct hash_entry> next;
 };
+
 typedef ptr<struct hash_entry> HashEntry;
 
 struct hash {
-  HashEntry *array; // Has count(size) bounds, but this currently errors
+  HashEntry *array : itype(array_ptr<HashEntry>);
   ptr<int(unsigned int)> mapfunc;
   int size;
 };

--- a/MultiSource/Benchmarks/Olden/mst/hash.h
+++ b/MultiSource/Benchmarks/Olden/mst/hash.h
@@ -13,7 +13,7 @@ struct hash_entry {
 typedef ptr<struct hash_entry> HashEntry;
 
 struct hash {
-  HashEntry *array : itype(array_ptr<HashEntry>);
+  array_ptr<HashEntry> array : count(size);
   ptr<int(unsigned int)> mapfunc;
   int size;
 };

--- a/MultiSource/Benchmarks/Olden/mst/main.c
+++ b/MultiSource/Benchmarks/Olden/mst/main.c
@@ -108,13 +108,15 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   Vertex inserted = NULL, tmp = NULL;
   int cost=0,dist;
 
+  dynamic_check(numproc <= MAXPROC);
+
   /* make copy of graph */
   printf("Compute phase 1\n");
 
   /* Insert first node */
-  inserted = graph->vlist[0];
+  inserted = (Vertex)graph->vlist[0].starting_vertex;
   tmp = inserted->next;
-  graph->vlist[0] = tmp;
+  graph->vlist[0].starting_vertex = tmp;
   MyVertexList = tmp;
   numvert--;
   /* Announce insertion and find next one */

--- a/MultiSource/Benchmarks/Olden/mst/main.c
+++ b/MultiSource/Benchmarks/Olden/mst/main.c
@@ -49,9 +49,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
       count++;
       if (tmp==inserted) 
         {
-          Vertex next = NULL;
-
-          next = tmp->next;
+          Vertex next = tmp->next;
           prev->next = next;
         }
       else 
@@ -107,8 +105,7 @@ static BlueReturn Do_all_BlueRule(Vertex inserted, int nproc, int pn) {
 
 static int ComputeMst(Graph graph,int numproc,int numvert) 
 {
-  VertexArr inserted : count(numproc) = NULL; 
-  VertexArr tmp : count(numproc) = NULL;
+  Vertex inserted = NULL, tmp = NULL;
   int cost=0,dist;
 
   /* make copy of graph */
@@ -135,7 +132,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   return cost;
 }
 
-int main(int argc, char *argv[]) 
+int main(int argc, array_ptr<char*> argv : count(argc))
 {
   Graph graph = NULL;
   int dist;

--- a/MultiSource/Benchmarks/Olden/mst/main.c
+++ b/MultiSource/Benchmarks/Olden/mst/main.c
@@ -16,8 +16,8 @@ typedef struct fc_br {
 static BlueReturn BlueRule(Vertex inserted, Vertex vlist) 
 {
   BlueReturn retval;
-  Vertex tmp,prev;
-  Hash hash;
+  Vertex tmp = NULL, prev = NULL;
+  Hash hash = NULL;
   int dist,dist2;
   int count;
   
@@ -49,7 +49,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
       count++;
       if (tmp==inserted) 
         {
-          Vertex next;
+          Vertex next = NULL;
 
           next = tmp->next;
           prev->next = next;
@@ -107,7 +107,8 @@ static BlueReturn Do_all_BlueRule(Vertex inserted, int nproc, int pn) {
 
 static int ComputeMst(Graph graph,int numproc,int numvert) 
 {
-  Vertex inserted,tmp;
+  VertexArr inserted : count(numproc) = NULL; 
+  VertexArr tmp : count(numproc) = NULL;
   int cost=0,dist;
 
   /* make copy of graph */
@@ -136,7 +137,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
 
 int main(int argc, char *argv[]) 
 {
-  Graph graph;
+  Graph graph = NULL;
   int dist;
   int size;
  

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -42,20 +42,19 @@ static void AddEdges(int count1, Graph retval, int numproc,
                      int perproc, int numvert, int j) 
 {
   Vertex tmp = NULL;
-  VertexArr helper checked[MAXPROC];
+  UncheckedVertex helper checked[MAXPROC];
   int i;
 
   for (i=0; i<numproc; i++) {
-    helper[i] = retval->vlist[i];
+    helper[i] = (UncheckedVertex)retval->vlist[i];
   }
 
-  for (tmp = (Vertex)(retval->vlist[j]); tmp; tmp=tmp->next) 
+  for (tmp = retval->vlist[j]; tmp; tmp=tmp->next)
     {
       for (i=0; i<numproc*perproc; i++) 
         {
           int pn,offset,dist;
-          // CHECKED C: This was converted using checked-c-convert
-          Vertex dest = NULL;
+          UncheckedVertex dest;
           Hash hash = NULL;
           
           if (i!=count1) 
@@ -63,9 +62,9 @@ static void AddEdges(int count1, Graph retval, int numproc,
               dist = compute_dist(i,count1,numvert);
               pn = i/perproc;
               offset = i % perproc;
-              dest = (Vertex)((helper[pn])+offset);
+              dest = ((helper[pn])+offset);
               hash = tmp->edgehash;
-              HashInsert((void *) dist,(unsigned int) dest,hash);
+              HashInsert((void*)dist,(unsigned int) dest,hash);
               /*assert(4, HashLookup((unsigned int) dest,hash) == (void*) dist);*/
             }
         } /* for i... */
@@ -79,7 +78,7 @@ Graph MakeGraph(int numvert, int numproc)
   int i,j;
   int count1;
   Vertex v = NULL, tmp = NULL;
-  VertexArr block : count(perproc) = NULL;
+  array_ptr<struct vert_st> block : count(perproc) = NULL;
   Graph retval = NULL;
   retval = (Graph)malloc(sizeof(*retval));
   for (i=0; i<MAXPROC; i++) 
@@ -89,18 +88,18 @@ Graph MakeGraph(int numvert, int numproc)
   chatting("Make phase 2\n");
   for (j=numproc-1; j>=0; j--) 
     {
-      block = malloc(perproc*(sizeof(*tmp)));
+      block = malloc(perproc*(sizeof(struct vert_st)));
       v = NULL;
       for (i=0; i<perproc; i++) 
         {
-          tmp = (Vertex)(block+(perproc-i-1));
+          tmp = block+(perproc-i-1);
           HashRange = numvert/4;
           tmp->mindist = 9999999;
           tmp->edgehash = MakeHash(numvert/4,hashfunc);
           tmp->next = v;
           v=tmp;
         }
-      retval->vlist[j] = (VertexArr)v;
+      retval->vlist[j] = v;
     }
 
   chatting("Make phase 3\n");

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -41,29 +41,29 @@ static int hashfunc(unsigned int key)
 static void AddEdges(int count1, Graph retval, int numproc, 
                      int perproc, int numvert, int j) 
 {
-  Vertex tmp;
-  Vertex helper[MAXPROC];
+  Vertex tmp = NULL;
+  VertexArr helper checked[MAXPROC];
   int i;
 
   for (i=0; i<numproc; i++) {
     helper[i] = retval->vlist[i];
   }
 
-  for (tmp = retval->vlist[j]; tmp; tmp=tmp->next) 
+  for (tmp = (Vertex)(retval->vlist[j]); tmp; tmp=tmp->next) 
     {
       for (i=0; i<numproc*perproc; i++) 
         {
           int pn,offset,dist;
           // CHECKED C: This was converted using checked-c-convert
-          _Ptr<struct vert_st>  dest;
-          Hash hash;
+          Vertex dest = NULL;
+          Hash hash = NULL;
           
           if (i!=count1) 
             {
               dist = compute_dist(i,count1,numvert);
               pn = i/perproc;
               offset = i % perproc;
-              dest = ((helper[pn])+offset);
+              dest = (Vertex)((helper[pn])+offset);
               hash = tmp->edgehash;
               HashInsert((void *) dist,(unsigned int) dest,hash);
               /*assert(4, HashLookup((unsigned int) dest,hash) == (void*) dist);*/
@@ -78,9 +78,9 @@ Graph MakeGraph(int numvert, int numproc)
   int perproc = numvert/numproc;
   int i,j;
   int count1;
-  Vertex v,tmp;
-  Vertex block;
-  Graph retval;
+  Vertex v = NULL, tmp = NULL;
+  VertexArr block : count(perproc) = NULL;
+  Graph retval = NULL;
   retval = (Graph)malloc(sizeof(*retval));
   for (i=0; i<MAXPROC; i++) 
     {
@@ -89,18 +89,18 @@ Graph MakeGraph(int numvert, int numproc)
   chatting("Make phase 2\n");
   for (j=numproc-1; j>=0; j--) 
     {
-      block = (Vertex) malloc(perproc*(sizeof(*tmp)));
+      block = malloc(perproc*(sizeof(*tmp)));
       v = NULL;
       for (i=0; i<perproc; i++) 
         {
-          tmp = block+(perproc-i-1);
+          tmp = (Vertex)(block+(perproc-i-1));
           HashRange = numvert/4;
           tmp->mindist = 9999999;
           tmp->edgehash = MakeHash(numvert/4,hashfunc);
           tmp->next = v;
           v=tmp;
         }
-      retval->vlist[j] = v;
+      retval->vlist[j] = (VertexArr)v;
     }
 
   chatting("Make phase 3\n");

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -42,7 +42,9 @@ static void AddEdges(int count1, Graph retval, int numproc,
                      int perproc, int numvert, int j) 
 {
   Vertex tmp = NULL;
-  array_ptr<VertexArray> helper : count(numproc) = NULL;
+  // CHECKED C: numproc must be less than MAXPROC,
+  // because of dynamic_check in MakeGraph
+  VertexArray helper checked[MAXPROC];
   int i;
 
   for (i=0; i<numproc; i++) {

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -54,7 +54,8 @@ static void AddEdges(int count1, Graph retval, int numproc,
       for (i=0; i<numproc*perproc; i++) 
         {
           int pn,offset,dist;
-          Vertex dest;
+          // CHECKED C: This was converted using checked-c-convert
+          _Ptr<struct vert_st>  dest;
           Hash hash;
           
           if (i!=count1) 

--- a/MultiSource/Benchmarks/Olden/mst/mst.h
+++ b/MultiSource/Benchmarks/Olden/mst/mst.h
@@ -16,10 +16,18 @@ struct vert_st {
 };
 
 typedef ptr<struct vert_st> Vertex;
-typedef struct vert_st *UncheckedVertex;
 
+struct vert_arr_st {
+  array_ptr<struct vert_st> block : count(len);
+  int len;
+  array_ptr<struct vert_st> starting_vertex : bounds(block, block + len);
+};
+
+typedef struct vert_arr_st VertexArray;
+
+// CHECKED C: We should probably verify that MAXPROC == NumNodes
 struct graph_st {
-  Vertex vlist checked[MAXPROC];
+  struct vert_arr_st vlist checked[MAXPROC];
 };
 
 typedef ptr<struct graph_st> Graph;

--- a/MultiSource/Benchmarks/Olden/mst/mst.h
+++ b/MultiSource/Benchmarks/Olden/mst/mst.h
@@ -1,23 +1,30 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
 #include <stdlib.h>
+#include <stdlib_checked.h>
 #include "hash.h"
 #define MAXPROC 1
 
 #define chatting printf
 extern int NumNodes;
 
-typedef struct vert_st {
+struct vert_st {
   int mindist;
-  struct vert_st *next;
+  ptr<struct vert_st> next;
   Hash edgehash;
-} *Vertex;
+};
 
-typedef struct graph_st {
-  Vertex vlist[MAXPROC];
-} *Graph;
+typedef ptr<struct vert_st> Vertex;
+typedef array_ptr<struct vert_st> VertexArr;
+
+struct graph_st {
+  VertexArr vlist checked[MAXPROC];
+};
+
+typedef ptr<struct graph_st> Graph;
 
 Graph MakeGraph(int numvert, int numproc);
-int dealwithargs(int argc, char *argv[]);
+int dealwithargs(int argc, array_ptr<char*> argv : count(argc));
 
 int atoi(const char *);

--- a/MultiSource/Benchmarks/Olden/mst/mst.h
+++ b/MultiSource/Benchmarks/Olden/mst/mst.h
@@ -16,10 +16,10 @@ struct vert_st {
 };
 
 typedef ptr<struct vert_st> Vertex;
-typedef array_ptr<struct vert_st> VertexArr;
+typedef struct vert_st *UncheckedVertex;
 
 struct graph_st {
-  VertexArr vlist checked[MAXPROC];
+  Vertex vlist checked[MAXPROC];
 };
 
 typedef ptr<struct graph_st> Graph;


### PR DESCRIPTION
Closes #16

The automatic converter struggles on this too (first commit). Then I spent some time struggling at it too. It's got a whole load of compile errors, and needs to be more thoroughly rewritten.

The issue is that somewhere in the code they allocate a block for several `struct vert_st`s, and then later on they use the fact they know this information to find them again. I have no idea what I'm going to do about this given:
- Breaking the malloc up will undoubtedly hurt performance
- We haven't accurately sorted out casts between array_ptr and ptr, which would be needed.
- I don't want to add fields to structs etc, and I'm also unconvinced that structs can accurately represent bounds on `array_ptr<T>` members (I seem to be getting crashes).

Do not merge for the moment - i think some of this needs discussing on Monday. 
