### PR TITLE
Modifies the Olden/perimeter benchmark for Checked C

### DIFF
--- a/MultiSource/Benchmarks/Olden/perimeter/args.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/args.c
@@ -1,5 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
+
 #ifndef TORONTO
 #include <cm/cmmd.h>
 #include <fcntl.h>
@@ -23,7 +25,7 @@ void filestuff()
 }
 #endif
 
-int dealwithargs(int argc, char *argv[])
+int dealwithargs(int argc, array_ptr<char*> argv : count(argc))
 {
   int level;
 

--- a/MultiSource/Benchmarks/Olden/perimeter/main.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/main.c
@@ -1,8 +1,11 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
 #include "perimeter.h"
 #include <stdio.h>
+#include <stdio_checked.h>
 #include <stdlib.h>
+#include <stdlib_checked.h>
 
 static int adj(Direction d, ChildType ct)
 {
@@ -60,9 +63,8 @@ static ChildType reflect(Direction d, ChildType ct)
 
 int CountTree(QuadTree tree) 
 {
-  QuadTree nw,ne,sw,se;
+  QuadTree nw = tree->nw, ne = tree->ne, sw = tree->sw, se = tree->se;
 
-  nw = tree->nw; ne = tree->ne; sw = tree->sw; se = tree->se;
   if (nw==NULL && ne==NULL && sw==NULL && se==NULL)
     return 1;
   else
@@ -93,10 +95,9 @@ static QuadTree child(QuadTree tree, ChildType ct)
 
 static QuadTree gtequal_adj_neighbor(QuadTree tree, Direction d)
 {
-  QuadTree q,parent;
+  QuadTree q = NULL, parent = tree->parent;
   ChildType ct;
   
-  parent=tree->parent;
   ct=tree->childtype;
   if ((parent!=NULL) && adj(d,ct))
     q=gtequal_adj_neighbor(parent,d);
@@ -124,11 +125,11 @@ static int sum_adjacent(QuadTree p, ChildType q1, ChildType q2, int size)
 int perimeter(QuadTree tree, int size)
 {
   int retval = 0;
-  QuadTree neighbor;
+  QuadTree neighbor = NULL;
 
   if (tree->color==grey) 
     {
-      QuadTree child;
+      QuadTree child = NULL;
 #ifdef FUTURES
       future_cell_int fc_sw,fc_se,fc_ne;
 #endif
@@ -183,11 +184,11 @@ int perimeter(QuadTree tree, int size)
   return retval;
 }
 
-extern int dealwithargs(int argc, char * argv[]);
+extern int dealwithargs(int argc, array_ptr<char*> argv : count(argc));
 
-int main(int argc, char *argv[])
+int main(int argc, array_ptr<char*> argv : count(argc))
 {
-  QuadTree tree;
+  QuadTree tree = NULL;
   int count;
   int level;
 

--- a/MultiSource/Benchmarks/Olden/perimeter/maketree.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/maketree.c
@@ -1,7 +1,9 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
+#include <stdchecked.h>
 #include "perimeter.h"
 #include <stdlib.h>
+#include <stdlib_checked.h>
 
 static int CheckOutside(int x, int y) 
 {
@@ -32,7 +34,7 @@ QuadTree MakeTree(int size, int center_x, int center_y, int lo_proc,
 		  int hi_proc, QuadTree parent, ChildType ct, int level) 
 {
   int intersect=0;
-  QuadTree retval;
+  QuadTree retval = NULL;
 
 #ifdef FUTURES
   retval = (QuadTree) ALLOC(lo_proc,sizeof(*retval));

--- a/MultiSource/Benchmarks/Olden/perimeter/maketree.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/maketree.c
@@ -39,7 +39,7 @@ QuadTree MakeTree(int size, int center_x, int center_y, int lo_proc,
 #ifdef FUTURES
   retval = (QuadTree) ALLOC(lo_proc,sizeof(*retval));
 #else
-  retval = (QuadTree) malloc(sizeof(*retval));
+  retval = (QuadTree) calloc(1, sizeof(*retval));
 #endif
   retval->parent = parent;
   retval->childtype = ct;

--- a/MultiSource/Benchmarks/Olden/perimeter/perimeter.h
+++ b/MultiSource/Benchmarks/Olden/perimeter/perimeter.h
@@ -1,4 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
+
+#include <stdchecked.h>
+
 #ifdef TORONTO
 extern int NumNodes;
 #define chatting      printf
@@ -24,20 +27,22 @@ typedef struct quad_struct {
   ChildType childtype;
 
 #ifndef TORONTO
-  struct quad_struct *nw {50};
-  struct quad_struct *ne {50};
-  struct quad_struct *sw {50};
-  struct quad_struct *se {50};
-  struct quad_struct *parent {50};
+  ptr<struct quad_struct> nw {50};
+  ptr<struct quad_struct> ne {50};
+  ptr<struct quad_struct> sw {50};
+  ptr<struct quad_struct> se {50};
+  ptr<struct quad_struct> parent {50};
 #else
-  struct quad_struct *nw;
-  struct quad_struct *ne;
-  struct quad_struct *sw;
-  struct quad_struct *se;
-  struct quad_struct *parent;
+  ptr<struct quad_struct> nw;
+  ptr<struct quad_struct> ne;
+  ptr<struct quad_struct> sw;
+  ptr<struct quad_struct> se;
+  ptr<struct quad_struct> parent;
 #endif
 
-} quad_struct, *QuadTree;
+} quad_struct;
+
+typedef ptr<struct quad_struct> QuadTree;
 
 
 QuadTree MakeTree(int size, int center_x, int center_y, int lo_proc,


### PR DESCRIPTION
Closes #18 

Checked-c-convert converted zero of the pointers in this benchmark.

Everything in the conversion should be straightforward, given this is basically all just using `ptr<T>` and not using `array_ptr<T>`