### PR TITLE
Replaces `malloc` with `calloc` in converted benchmarks

### DIFF
--- a/MultiSource/Benchmarks/Olden/bisort/bitonic.c
+++ b/MultiSource/Benchmarks/Olden/bisort/bitonic.c
@@ -20,7 +20,7 @@ int flag=0,foo=0;
 
 #define LocalNewNode(h,v) \
 { \
-    h = (ptr<HANDLE>) malloc(sizeof(struct node)); \
+    h = (ptr<HANDLE>) calloc(1,sizeof(struct node)); \
       h->value = v; \
 	h->left = NIL; \
 	  h->right = NIL; \

--- a/MultiSource/Benchmarks/Olden/health/health.c
+++ b/MultiSource/Benchmarks/Olden/health/health.c
@@ -24,7 +24,7 @@ ptr<struct Village> alloc_tree(int level, int label, ptr<struct Village> back) {
     int                  i;
     ptr<struct Village>  fval checked[4] = { NULL, NULL, NULL, NULL };
 
-    new = (ptr<struct Village>)malloc(sizeof(struct Village));
+    new = calloc(1, sizeof(struct Village));
 
     for (i = 3; i >= 0; i--)
       fval[i] = alloc_tree(level - 1, label*4 + i + 1, new); 
@@ -208,7 +208,7 @@ ptr<struct Patient> generate_patient(ptr<struct Village> village)
   newseed = village->seed;
   label = village->label;
   if (rand > 0.666) {
-    patient = (struct Patient *)malloc(sizeof(struct Patient));
+    patient = calloc(1, sizeof(struct Patient));
     patient->hosps_visited = 0;
     patient->time = 0;
     patient->time_left = 0;

--- a/MultiSource/Benchmarks/Olden/health/list.c
+++ b/MultiSource/Benchmarks/Olden/health/list.c
@@ -19,7 +19,7 @@ void addList(ptr<struct List> list, ptr<struct Patient> patient) {
     b = list;
     list = list->forward; }
   
-  list = (ptr<struct List>)malloc(sizeof(struct List));
+  list = calloc(1, sizeof(struct List));
   list->patient = patient;
   list->forward = NULL;
   list->back = b;


### PR DESCRIPTION
This was something I missed before. 

We're converting all the benchmarks to use calloc, mostly because calloc will zero-initialize any structs containing ptrs, which means any ptrs start as NULL, not whatever value was in them before. This means all our non-null checks will remain sound. 