### PR TITLE
Convet malloc to calloc in Olden/Ptrdist benchmarks

### DIFF
--- a/MultiSource/Benchmarks/Olden/power/build.c
+++ b/MultiSource/Benchmarks/Olden/power/build.c
@@ -22,7 +22,7 @@ Root build_tree(void)
   Root t = 0;
   Lateral l = 0;
 
-  t = (Root) malloc(sizeof(*t));
+  t = (Root) calloc(1, sizeof(*t));
 
   for (i=0; i<NUM_FEEDERS; i++) {
     /* Insert future here, split into two loops */
@@ -45,7 +45,7 @@ Lateral build_lateral(int i, int num)
   Lateral next = 0;
  
   if (num == 0) return NULL;
-  l = (Lateral) malloc(sizeof(*l));
+  l = (Lateral) calloc(1, sizeof(*l));
 
   next = build_lateral(i,num-1);
   b = build_branch(i*BRANCHES_PER_LATERAL,(num-1)*BRANCHES_PER_LATERAL,
@@ -70,7 +70,7 @@ Branch build_branch(int i, int j, int num)
 
   if (num == 0) return NULL;
   /* allocate branch */
-  b = (Branch) malloc(sizeof(*b));
+  b = (Branch) calloc(1, sizeof(*b));
   
   /* fill in children */
   // CHECKEDC : p->m == (*p).m, ptr type dereference, non-null check
@@ -104,7 +104,7 @@ Leaf build_leaf(void) {
   // CHECKEDC : automatic checked pointer must have a initializer
   Leaf l = 0;
 
-  l = (Leaf) malloc(sizeof(*l));
+  l = (Leaf) calloc(1, sizeof(*l));
   // CHECKEDC : ptr type dereference (l->)
   // dynamic_check(l != NULL);
   l->D.P = 1.0;

--- a/MultiSource/Benchmarks/Olden/treeadd/par-alloc.c
+++ b/MultiSource/Benchmarks/Olden/treeadd/par-alloc.c
@@ -15,7 +15,7 @@ ptr<tree_t> TreeAlloc (int level, int lo, int proc) {
     return NULL;
   else {
     ptr<tree_t> new = NULL, right = NULL, left = NULL;
-    new = (ptr<tree_t>) malloc(sizeof(tree_t));
+    new = (ptr<tree_t>) calloc(1, sizeof(tree_t));
     left = TreeAlloc(level -1, lo+proc/2, proc/2);
     right=TreeAlloc(level-1,lo,proc/2);
     new->val = 1;

--- a/MultiSource/Benchmarks/Olden/tsp/tsp.h
+++ b/MultiSource/Benchmarks/Olden/tsp/tsp.h
@@ -5,7 +5,7 @@
 
 #ifdef TORONTO
 /* Toronto's hack */
-#define ALLOC(p, sz)      malloc(sz)
+#define ALLOC(p, sz)      calloc(1, sz)
 #define chatting          printf  
 extern int NumNodes, NDim;
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -303,7 +303,7 @@ void ReadDict(char *pchFile : itype(_Ptr<char>)) {
     // buffer : count(ulLen)
     // pchDictionary : count(pchDictionarySize)
     // dynamic_check(pchDictionarySize == ulLen);
-    pchBase = buffer = pchDictionary = malloc(pchDictionarySize);
+    pchBase = buffer = pchDictionary = calloc(pchDictionarySize, sizeof(char));
 
     if(pchDictionary == NULL)
 	Fatal("Unable to allocate memory for dictionary\n", 0);
@@ -424,7 +424,7 @@ void BuildMask(_Array_ptr<char> pchPhrase : bounds(achPhrase, achPhrase+255)) {
 
 // CHECKEDC
 PWord NewWord(void) {
-    PWord pw = malloc(sizeof(Word));
+    PWord pw = calloc(1, sizeof(Word));
     if (pw == NULL)
         Fatal("Out of memory after %d candidates\n", cpwCand);
     return pw;

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
@@ -524,7 +524,7 @@ NewHeap(_Ptr<Item>  i)
     // CHECKEDC : automatic variable initialize required
   _Ptr<HeapP>  h = 0;
 
-  h = (HeapP *)malloc(sizeof(HeapP));
+  h = (HeapP *)calloc(1, sizeof(HeapP));
 
   if(h == NULL)
   {

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.c
@@ -231,7 +231,7 @@ NewVertex(void)
     // CHECKEDC : automatic variable initialize required
   _Ptr<Vertices>  vertex = 0;
 
-  vertex = malloc(sizeof(Vertices));
+  vertex = calloc(1, sizeof(Vertices));
 
   if(vertex == NULL)
   {
@@ -252,7 +252,7 @@ NewEdge(void)
     // CHECKEDC : automatic variable initialize required
   _Ptr<Edges>  edge = 0;
 
-  edge = malloc(sizeof(Edges));
+  edge = calloc(1, sizeof(Edges));
 
   if(edge == NULL)
   {

--- a/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
+++ b/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
@@ -63,7 +63,7 @@ ReadNetList(char *fname : itype(_Ptr<char>))
     // CHECKEDC : allocated pointer non-null check can be removed
     // since compiler insert dynamic non-null check before dereference of _Ptr pointer type
     // static checking is unnecessary with checkedc extension
-	TRY(head = prev = malloc(sizeof(Module)),
+	TRY(head = prev = calloc(1, sizeof(Module)),
 	    prev != NULL, "ReadData",
 	    "unable to allocate a module list node", 0, 0, 0,
 	    exit(1));
@@ -72,7 +72,7 @@ ReadNetList(char *fname : itype(_Ptr<char>))
 	(*prev).module = atol(strtok(NULL, " \t\n"))-1;
 	(*prev).next = NULL;
 	while ((tok = strtok(NULL, " \t\n")) != NULL) {
-	    TRY(node = malloc(sizeof(Module)),
+	    TRY(node = calloc(1, sizeof(Module)),
 		node != NULL, "ReadData",
 		"unable to allocate a module list node", 0, 0, 0,
 		exit(1));
@@ -112,7 +112,7 @@ NetsToModules(void)
         // dynamic_check(net >= 0 && net < G_SZ)
         // programmer-inserted dynamic_check can remove unnecessary bounds check
 	for (modNode = nets[net]; modNode != NULL; modNode = (*modNode).next) {
-	    TRY(netNode = malloc(sizeof(Net)),
+	    TRY(netNode = calloc(1, sizeof(Net)),
 		netNode != NULL, "NetsToModules",
 		"unable to allocate net list node", 0, 0, 0,
 		exit(1));
@@ -175,7 +175,7 @@ InitLists(void)
 	/* build the group A module list */
         // CHECKEDC : checkedc pointer type non-null check at dereference
         // dynamic_check(mr != NULL)
-	TRY(mr = malloc(sizeof(ModuleRec)),
+	TRY(mr = calloc(1, sizeof(ModuleRec)),
 	    mr != NULL, "main",
 	    "unable to allocate ModuleRec", 0, 0, 0,
 	    exit(1));
@@ -201,7 +201,7 @@ InitLists(void)
 
 	/* build the group B module list */
     // CHECKEDC : _Ptr dereference (non-null check)
-	TRY(mr = malloc(sizeof(ModuleRec)),
+	TRY(mr = calloc(1, sizeof(ModuleRec)),
 	    mr != NULL, "main",
 	    "unable to allocate ModuleRec", 0, 0, 0,
 	    exit(1));


### PR DESCRIPTION
I just did a second check-over of the benchmarks as converted by @wonsubkim and @jijoongmoon, looking for two things:
- uses of `malloc` (which this PR changes to `calloc`)
- uses of `array_ptr<T> field : count(otherfield);` in structs, because the latter causes an ICE as documented in Microsoft/checkedc-clang#244

This PR changes the former.

There is only one of the latter, in `anagram.c`, the compiler doesn't ICE, because there's also a local with the same name (and type) as the field in the struct. I'll dump the AST shortly, and add it as a comment to that issue. 