### PR TITLE
Fix typo in conversion of Olden em3d benchmark.

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -72,7 +72,7 @@ void make_neighbors(ptr<node_t> nodelist, array_ptr<table_arr_t> table : count(P
       chatting("Uncaught calloc error\n");
       exit(0);
     }
-    curr_node->degree = degree;
+    cur_node->degree = degree;
 
     for (j=0; j<degree; j++) {
       do {


### PR DESCRIPTION
With this change and the corresponding compilers fix for https://github.com/Microsoft/checkedc-clang/issues/280, em3d now compiles.  However, it fails when run.  I have not investigated the runtime failure.
