### PR TITLE
Remove Replaced Unchecked Headers

### DIFF
--- a/MultiSource/Benchmarks/Olden/bisort/args.c
+++ b/MultiSource/Benchmarks/Olden/bisort/args.c
@@ -1,5 +1,4 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
-#include <stdlib.h>
 #include <stdchecked.h>
 #include <stdlib_checked.h>
 

--- a/MultiSource/Benchmarks/Olden/bisort/bitonic.c
+++ b/MultiSource/Benchmarks/Olden/bisort/bitonic.c
@@ -5,7 +5,6 @@
 #include "node.h"   /* Node Definition */
 #include "proc.h"   /* Procedure Types/Nums */
 #include <stdchecked.h>
-#include <stdio.h>
 #include <stdio_checked.h>
 
 #define CONST_m1 10000

--- a/MultiSource/Benchmarks/Olden/em3d/em3d.h
+++ b/MultiSource/Benchmarks/Olden/em3d/em3d.h
@@ -17,9 +17,7 @@ void printstats(void);
 void srand48(long);
 long lrand48(void);
 
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 
 #define chatting printf

--- a/MultiSource/Benchmarks/Olden/em3d/util.c
+++ b/MultiSource/Benchmarks/Olden/em3d/util.c
@@ -1,6 +1,6 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdlib.h>
+#include <stdlib_checked.h>
 #include "em3d.h"
 
 #ifdef TORONTO

--- a/MultiSource/Benchmarks/Olden/health/args.c
+++ b/MultiSource/Benchmarks/Olden/health/args.c
@@ -6,9 +6,7 @@
  *****************************************************************/
 
 #include <stdchecked.h>
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 #include "health.h"
 

--- a/MultiSource/Benchmarks/Olden/health/health.c
+++ b/MultiSource/Benchmarks/Olden/health/health.c
@@ -4,9 +4,7 @@
  *  Health.c : Model of the Columbian Health Care System           *
  *******************************************************************/ 
 
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 #include <math.h>
 #include "health.h"

--- a/MultiSource/Benchmarks/Olden/health/health.h
+++ b/MultiSource/Benchmarks/Olden/health/health.h
@@ -9,9 +9,7 @@
 #define _HEALTH
 
 #include <stdchecked.h>
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 
 #define chatting printf

--- a/MultiSource/Benchmarks/Olden/health/list.c
+++ b/MultiSource/Benchmarks/Olden/health/list.c
@@ -6,9 +6,7 @@
  ********************************************************************/
 
 #include <stdchecked.h>
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 #include "health.h"
 

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -1,7 +1,6 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include <stdchecked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 #include "hash.h"
 

--- a/MultiSource/Benchmarks/Olden/mst/hash.h
+++ b/MultiSource/Benchmarks/Olden/mst/hash.h
@@ -1,7 +1,6 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include <stdchecked.h>
-#include "stdio.h"
 #include <stdio_checked.h>
 
 struct hash_entry {

--- a/MultiSource/Benchmarks/Olden/mst/mst.h
+++ b/MultiSource/Benchmarks/Olden/mst/mst.h
@@ -1,7 +1,6 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include <stdchecked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 #include "hash.h"
 #define MAXPROC 1

--- a/MultiSource/Benchmarks/Olden/perimeter/main.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/main.c
@@ -2,9 +2,7 @@
 
 #include <stdchecked.h>
 #include "perimeter.h"
-#include <stdio.h>
 #include <stdio_checked.h>
-#include <stdlib.h>
 #include <stdlib_checked.h>
 
 static int adj(Direction d, ChildType ct)

--- a/MultiSource/Benchmarks/Olden/perimeter/maketree.c
+++ b/MultiSource/Benchmarks/Olden/perimeter/maketree.c
@@ -2,7 +2,6 @@
 
 #include <stdchecked.h>
 #include "perimeter.h"
-#include <stdlib.h>
 #include <stdlib_checked.h>
 
 static int CheckOutside(int x, int y) 


### PR DESCRIPTION
This was also noise in the statistics, and I think it's also good that we show better code than we had originally. There's no need to leave the old include lines, as the checked headers start with them anyway.