### PR TITLE
Add Checked Blocks/Pragmas to Olden/em3d, Olden/health, Olden/mst

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/args.c
+++ b/MultiSource/Benchmarks/Olden/em3d/args.c
@@ -8,6 +8,8 @@
 #include <fcntl.h>
 #endif
 
+#pragma BOUNDS_CHECKED ON
+
 #ifdef TORONTO
 int NumNodes;
 #else
@@ -19,7 +21,7 @@ extern int __NumNodes;
 extern int DebugFlag;
 
 #ifndef TORONTO
-void filestuff()
+unchecked void filestuff()
 {
   CMMD_fset_io_mode(stdout, CMMD_independent);
   fcntl(fileno(stdout), F_SETFL, O_APPEND);
@@ -28,7 +30,7 @@ void filestuff()
 }
 #endif
 
-void dealwithargs(int argc, array_ptr<char*> argv : count(argc))
+unchecked void dealwithargs(int argc, array_ptr<char*> argv : count(argc))
 {
 #ifdef TORONTO
   if (argc > 4)

--- a/MultiSource/Benchmarks/Olden/em3d/em3d.c
+++ b/MultiSource/Benchmarks/Olden/em3d/em3d.c
@@ -1,6 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include "em3d.h"
+#pragma BOUNDS_CHECKED ON
 int nonlocals=0;
 void compute_nodes(nodelist)
 register ptr<node_t> nodelist;

--- a/MultiSource/Benchmarks/Olden/em3d/em3d.h
+++ b/MultiSource/Benchmarks/Olden/em3d/em3d.h
@@ -12,7 +12,7 @@
 
 #include <stdchecked.h>
 
-void dealwithargs(int argc, array_ptr<char*> argv : count(argc));
+unchecked void dealwithargs(int argc, array_ptr<char*> argv : count(argc));
 void printstats(void);
 void srand48(long);
 long lrand48(void);
@@ -22,6 +22,7 @@ long lrand48(void);
 #include <stdlib.h>
 #include <stdlib_checked.h>
 
+#pragma BOUNDS_CHECKED ON
 #define chatting printf
 
 // extern char * min_ptr;
@@ -32,7 +33,7 @@ extern int d_nodes; /* degree of nodes */
 extern int local_p; /* percentage of local edges */
 #define PROCS 1
 
-#define assert(a) if (!a) {printf("Assertion failure\n"); exit(-1);}
+#define assert(a) if (!a) unchecked { printf("Assertion failure\n"); exit(-1); }
 
 typedef struct node_t {
   ptr<double> value;
@@ -64,4 +65,5 @@ typedef struct table_t {
 void compute_nodes(ptr<node_t> nodelist);
 double gen_uniform_double(void);
 
+#pragma BOUNDS_CHECKED OFF
 #endif

--- a/MultiSource/Benchmarks/Olden/em3d/main.c
+++ b/MultiSource/Benchmarks/Olden/em3d/main.c
@@ -16,13 +16,13 @@ unchecked void print_graph(ptr<graph_t> graph, int id)
   for(; cur_node; cur_node=cur_node->next)
     {
       chatting("E: value %f, from_count %d\n", *cur_node->value,
-               cur_node->from_count);
+	       cur_node->from_count);
     }
   cur_node=graph->h_nodes[id];
   for(; cur_node; cur_node=cur_node->next)
     {
       chatting("H: value %f, from_count %d\n", *cur_node->value,
-	             cur_node->from_count);
+	       cur_node->from_count);
     }
 }
 

--- a/MultiSource/Benchmarks/Olden/em3d/main.c
+++ b/MultiSource/Benchmarks/Olden/em3d/main.c
@@ -3,31 +3,32 @@
 #include "em3d.h"
 #include "make_graph.h"
 #include <stdchecked.h>
+#pragma BOUNDS_CHECKED ON
 
 extern int NumNodes;
 
 int DebugFlag;
 
-void print_graph(ptr<graph_t> graph, int id) 
+unchecked void print_graph(ptr<graph_t> graph, int id)
 {
   ptr<node_t> cur_node = graph->e_nodes[id];
 
   for(; cur_node; cur_node=cur_node->next)
     {
       chatting("E: value %f, from_count %d\n", *cur_node->value,
-	       cur_node->from_count);
+               cur_node->from_count);
     }
   cur_node=graph->h_nodes[id];
   for(; cur_node; cur_node=cur_node->next)
     {
       chatting("H: value %f, from_count %d\n", *cur_node->value,
-	       cur_node->from_count);
+	             cur_node->from_count);
     }
 }
 
 extern int nonlocals;
 
-int main(int argc, array_ptr<char*> argv : count(argc))
+unchecked int main(int argc, array_ptr<char*> argv : count(argc))
 {
   int i;
   ptr<graph_t> graph = NULL;
@@ -41,10 +42,10 @@ int main(int argc, array_ptr<char*> argv : count(argc))
     for(i=0; i<NumNodes;i++)
       print_graph(graph,i);
 
-
+  checked {
   compute_nodes(graph->e_nodes[0]);
   compute_nodes(graph->h_nodes[0]);
-  
+  }
   chatting("nonlocals = %d\n",nonlocals);
 
   printstats();

--- a/MultiSource/Benchmarks/Olden/em3d/util.c
+++ b/MultiSource/Benchmarks/Olden/em3d/util.c
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 #include "em3d.h"
+#pragma BOUNDS_CHECKED ON
 
 #ifdef TORONTO
 #define chatting printf
@@ -12,7 +13,7 @@
 #define lrand48() (rand() << 16 | rand())
 #define drand48() (1.0*rand() / RAND_MAX)
 #else
-extern double drand48();
+extern double drand48(void);
 #endif
 
 static int percentcheck=0,numlocal=0;
@@ -41,7 +42,7 @@ int gen_signed_number(int range)
 }
 
 /* Generate a double from 0.0 to 1.0 */
-double gen_uniform_double()
+double gen_uniform_double(void)
 {
   return drand48();
 }
@@ -55,7 +56,7 @@ int check_percent(int percent)
   return retval;
 }
 
-void printstats()
+unchecked void printstats()
 {
   chatting("percentcheck=%d,numlocal=%d\n",percentcheck,numlocal);
 }

--- a/MultiSource/Benchmarks/Olden/health/args.c
+++ b/MultiSource/Benchmarks/Olden/health/args.c
@@ -12,7 +12,7 @@
 #include <stdlib_checked.h>
 #include "health.h"
 
-void dealwithargs(int argc, array_ptr<char*> argv : count(argc)) {
+unchecked void dealwithargs(int argc, array_ptr<char*> argv : count(argc)) {
   if (argc < 4) {
     max_level = 3;
     max_time = 15;

--- a/MultiSource/Benchmarks/Olden/health/health.c
+++ b/MultiSource/Benchmarks/Olden/health/health.c
@@ -11,6 +11,7 @@
 #include <math.h>
 #include "health.h"
 #include <assert.h>
+#pragma BOUNDS_CHECKED ON
 
 int  max_level;
 long max_time;
@@ -217,7 +218,7 @@ ptr<struct Patient> generate_patient(ptr<struct Village> village)
   return NULL; 
 }
 
-int main(int argc, array_ptr<char*> argv : count(argc))
+unchecked int main(int argc, array_ptr<char*> argv : count(argc))
 { 
   struct Results         results;
   ptr<struct Village>    top = NULL;
@@ -232,14 +233,16 @@ int main(int argc, array_ptr<char*> argv : count(argc))
   
   for (i = 0; i < max_time; i++) {
     if ((i % 50) == 0) chatting("%d\n", i);
-    sim(top);
+    checked { sim(top); }
   }                          /* :) adt_pf detected */
   
   printf("Getting Results\n");
+  checked {
   results = get_results(top);              /* :) adt_pf detected */
   total_patients = results.total_patients;
   total_time = results.total_time;
   total_hosps = results.total_hosps;
+  }
 
   chatting("Done.\n\n");
   chatting("# of people treated:              %f people\n",

--- a/MultiSource/Benchmarks/Olden/health/health.h
+++ b/MultiSource/Benchmarks/Olden/health/health.h
@@ -13,6 +13,7 @@
 #include <stdio_checked.h>
 #include <stdlib.h>
 #include <stdlib_checked.h>
+#pragma BOUNDS_CHECKED ON
 
 #define chatting printf
 
@@ -85,7 +86,7 @@ struct Village {
 };
 
 ptr<struct Village> alloc_tree(int level, int label, ptr<struct Village> back);
-void dealwithargs(int argc, array_ptr<char*> argv : count(argc));
+unchecked void dealwithargs(int argc, array_ptr<char*> argv : count(argc));
 float my_rand(long long idum);
 ptr<struct Patient> generate_patient(ptr<struct Village> village);
 void put_in_hosp(ptr<struct Hosp> hosp, ptr<struct Patient>patient);
@@ -100,5 +101,6 @@ float get_total_time(ptr<struct Village> village);
 float get_total_hosps(ptr<struct Village> village);
 struct Results get_results(ptr<struct Village> village);
 
+#pragma BOUNDS_CHECKED OFF
 #endif
 

--- a/MultiSource/Benchmarks/Olden/health/list.c
+++ b/MultiSource/Benchmarks/Olden/health/list.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <stdlib_checked.h>
 #include "health.h"
+#pragma BOUNDS_CHECKED ON
 
 void addList(ptr<struct List> list, ptr<struct Patient> patient) {
   ptr<struct List> b = NULL;

--- a/MultiSource/Benchmarks/Olden/health/poisson.c
+++ b/MultiSource/Benchmarks/Olden/health/poisson.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <math.h>
 #include "health.h"
+#pragma BOUNDS_CHECKED ON
 
 float my_rand(long long idum)
 {

--- a/MultiSource/Benchmarks/Olden/mst/args.c
+++ b/MultiSource/Benchmarks/Olden/mst/args.c
@@ -1,12 +1,13 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include <stdchecked.h>
+#pragma BOUNDS_CHECKED ON
 
-extern int atoi(const char *);
+unchecked extern int atoi(const char *);
 
 int NumNodes = 1;
 
-int dealwithargs(int argc, array_ptr<char*> argv : count(argc)) {
+unchecked int dealwithargs(int argc, array_ptr<char*> argv : count(argc)) {
   int level;
 
   if (argc > 1)

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -4,8 +4,9 @@
 #include <stdlib.h>
 #include <stdlib_checked.h>
 #include "hash.h"
+#pragma BOUNDS_CHECKED ON
 
-#define assert(num,a) if (!(a)) {printf("Assertion failure:%d in hash\n",num); exit(-1);}
+#define assert(num,a) if (!(a)) unchecked {printf("Assertion failure:%d in hash\n",num); exit(-1);}
 
 static int remaining = 0;
 static array_ptr<char> temp : count(remaining);
@@ -44,7 +45,7 @@ Hash MakeHash(int size, ptr<int(unsigned int)> map)
   return retval;
 }
 
-void *HashLookup(unsigned int key, Hash hash)
+unchecked void *HashLookup(unsigned int key, Hash hash)
 {
   int j;
   HashEntry ent = NULL;
@@ -60,7 +61,7 @@ void *HashLookup(unsigned int key, Hash hash)
   return NULL;
 }
 
-void HashInsert(void *entry,unsigned int key,Hash hash) 
+unchecked void HashInsert(void *entry,unsigned int key,Hash hash)
 {
   HashEntry ent = NULL;
   int j;

--- a/MultiSource/Benchmarks/Olden/mst/hash.h
+++ b/MultiSource/Benchmarks/Olden/mst/hash.h
@@ -10,6 +10,8 @@ struct hash_entry {
   ptr<struct hash_entry> next;
 };
 
+#pragma BOUNDS_CHECKED ON
+
 typedef ptr<struct hash_entry> HashEntry;
 
 struct hash {
@@ -21,6 +23,8 @@ struct hash {
 typedef ptr<struct hash> Hash;
 
 Hash MakeHash(int size, ptr<int(unsigned int)> map);
-void *HashLookup(unsigned int key, Hash hash);
-void HashInsert(void *entry, unsigned int key, Hash hash);
+unchecked void *HashLookup(unsigned int key, Hash hash);
+unchecked void HashInsert(void *entry, unsigned int key, Hash hash);
 void HashDelete(unsigned int key, Hash hash);
+
+#pragma BOUNDS_CHECKED OFF

--- a/MultiSource/Benchmarks/Olden/mst/main.c
+++ b/MultiSource/Benchmarks/Olden/mst/main.c
@@ -1,6 +1,7 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include "mst.h"
+#pragma BOUNDS_CHECKED ON
 
 typedef struct blue_return {
   Vertex vert;
@@ -30,7 +31,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
   retval.vert = vlist;
   retval.dist = vlist->mindist;
   hash = vlist->edgehash;
-  dist = (int) HashLookup((unsigned int) inserted, hash);
+  unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
   /*printf("Found %d at 0x%x for 0x%x\n",dist,inserted,vlist);*/
   if (dist) 
     {
@@ -40,7 +41,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
           retval.dist = dist;
         }
     }
-  else printf("Not found\n");
+  else unchecked{ printf("Not found\n"); }
   
   count = 0;
   /* We are guaranteed that inserted is not first in list */
@@ -56,7 +57,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
         {
           hash = tmp->edgehash; /* <------  6% miss in tmp->edgehash */ 
           dist2 = tmp->mindist;
-          dist = (int) HashLookup((unsigned int) inserted, hash);
+          unchecked { dist = (int) HashLookup((unsigned int) inserted, hash); }
           /*printf("Found %d at 0x%x for 0x%x\n",dist,inserted,tmp);*/
           if (dist) 
             {
@@ -66,7 +67,7 @@ static BlueReturn BlueRule(Vertex inserted, Vertex vlist)
                   dist2 = dist;
                 }
             }
-          else printf("Not found\n");
+          else unchecked { printf("Not found\n"); }
           if (dist2<retval.dist) 
             {
               retval.vert = tmp;
@@ -111,7 +112,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   dynamic_check(numproc <= MAXPROC);
 
   /* make copy of graph */
-  printf("Compute phase 1\n");
+  unchecked { printf("Compute phase 1\n"); }
 
   /* Insert first node */
   inserted = (Vertex)graph->vlist[0].starting_vertex;
@@ -120,7 +121,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   MyVertexList = tmp;
   numvert--;
   /* Announce insertion and find next one */
-  printf("Compute phase 2\n");
+  unchecked { printf("Compute phase 2\n"); }
   while (numvert) 
     {
       BlueReturn br;
@@ -134,7 +135,7 @@ static int ComputeMst(Graph graph,int numproc,int numvert)
   return cost;
 }
 
-int main(int argc, array_ptr<char*> argv : count(argc))
+unchecked int main(int argc, array_ptr<char*> argv : count(argc))
 {
   Graph graph = NULL;
   int dist;
@@ -143,12 +144,12 @@ int main(int argc, array_ptr<char*> argv : count(argc))
   size = dealwithargs(argc,argv);
   printf("Making graph of size %d\n",size);
 
-  graph = MakeGraph(size,NumNodes);
+  checked { graph = MakeGraph(size,NumNodes); }
   printf("Graph completed\n");
 
   printf("About to compute mst \n");
 
-  dist = ComputeMst(graph,NumNodes,size);
+  checked { dist = ComputeMst(graph,NumNodes,size); }
 
   printf("MST has cost %d\n",dist);
   exit(0);

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -1,9 +1,10 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include "mst.h"
+#pragma BOUNDS_CHECKED ON
 
 /*#define assert(num,a) \
-   if (!(a)) {printf("Assertion failure:%d in makegraph\n",num); exit(-1);}*/
+   if (!(a)) unchecked {printf("Assertion failure:%d in makegraph\n",num); exit(-1);}*/
 
 #define CONST_m1 10000
 #define CONST_b 31415821
@@ -64,7 +65,7 @@ static void AddEdges(int count1, Graph retval, int numproc,
               offset = i % perproc;
               dest = ((helper[pn].block)+offset);
               hash = tmp->edgehash;
-              HashInsert((void*)dist,(unsigned int) dest,hash);
+              unchecked { HashInsert((void*)dist,(unsigned int) dest,hash); }
               /*assert(4, HashLookup((unsigned int) dest,hash) == (void*) dist);*/
             }
         } /* for i... */
@@ -88,7 +89,7 @@ Graph MakeGraph(int numvert, int numproc)
     {
       retval->vlist[i].starting_vertex = NULL;
     }
-  chatting("Make phase 2\n");
+  unchecked { chatting("Make phase 2\n"); }
   for (j=numproc-1; j>=0; j--) 
     {
       block = calloc(perproc, sizeof(*tmp));
@@ -107,15 +108,15 @@ Graph MakeGraph(int numvert, int numproc)
       retval->vlist[j].starting_vertex = v;
     }
 
-  chatting("Make phase 3\n");
+  unchecked { chatting("Make phase 3\n"); }
   for (j=numproc-1; j>=0; j--) 
     {
       count1 = j*perproc;
       AddEdges(count1, retval, numproc, perproc, numvert, j);
     } /* for j... */
-  chatting("Make phase 4\n");
+  unchecked { chatting("Make phase 4\n"); }
 
-  chatting("Make returning\n");
+  unchecked { chatting("Make returning\n"); }
   return retval;
 }
 

--- a/MultiSource/Benchmarks/Olden/mst/mst.h
+++ b/MultiSource/Benchmarks/Olden/mst/mst.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <stdlib_checked.h>
 #include "hash.h"
+#pragma BOUNDS_CHECKED ON
 #define MAXPROC 1
 
 #define chatting printf
@@ -32,6 +33,8 @@ struct graph_st {
 typedef ptr<struct graph_st> Graph;
 
 Graph MakeGraph(int numvert, int numproc);
-int dealwithargs(int argc, array_ptr<char*> argv : count(argc));
+unchecked int dealwithargs(int argc, array_ptr<char*> argv : count(argc));
 
-int atoi(const char *);
+unchecked int atoi(const char *);
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -10,6 +10,12 @@
 /////////////////////////////////////////////////////////////////////////
 #include <stdlib.h>
 
+// The Mac OS X Headers overwrite NULL to expand to ((void*) 0)
+// which doesn't work in a checked scope. 0 will work fine.
+#ifdef __DARWIN_NULL
+#define NULL 0
+#endif
+
 // TODO: strings
 // double atof(const char *s);
 // int atoi(const char *s);


### PR DESCRIPTION
This adds Checked blocks and pragmas to as much code in the following benchmarks as possible:
- Olden/em3d
- Olden/health
- Olden/mst

In almost all cases I've tried to keep the number of changed lines to a reasonable minimum. 

Local benchmark headers have had a `#pragma BOUNDS_CHECKED ON` at the top, and importantly, `#pragma BOUNDS_CHECKED OFF` at the bottom, so that we don't have to reorder any other headers.

With logging, I've tried to keep `chatting` invocations on one line, rather than having the `checked` block start on the previous line.

There's a bug on Mac OS X where `NULL` is a macro that expands (via `__DARWIN_NULL`) to `((void*) 0)` which is annoying, so I added a hack to `stdlib_checked.h` to get rid of the error. This seemed a reasonable approach, but I've not seen the equivalent errors on Linux yet. 

This caught two unintended uses of unchecked pointers in Olden/em3d, which is good. I've fixed them in this PR. 

There's still an issue with bounds interop types and `calloc`, but I've not seen the same error with any other functions, which is fantastic (all printf's are inside unchecked blocks as we don't yet support null-terminated strings)