### PR TITLE
Revert "Removes Checked Headers"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,10 +41,7 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   )
 
-if(NOT CHECKEDC_SPEC_DIR)
-  message(FATAL_ERROR "Must define CHECKEDC_SPEC_DIR so we can find CheckedC's headers")
-endif()
-include_directories(BEFORE ${CHECKEDC_SPEC_DIR}/include)
+set(LLVM_TEST_SUITE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Sanity check our source directory to make sure that we are not trying to
 # generate an in-tree build (unless on MSVC_IDE, where it is ok), and to make
@@ -190,7 +187,8 @@ if(NOT TEST_SUITE_SUBDIRS)
     get_filename_component(subdir ${entry} DIRECTORY)
     # Exclude tools and CTMark from default list
     if(NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/tools AND
-       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/CTMark)
+       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/CTMark AND
+       NOT ${subdir} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR}/include)
       list(APPEND TEST_SUITE_SUBDIRS ${subdir})
     endif()
   endforeach()

--- a/cmake/modules/SingleMultiSource.cmake
+++ b/cmake/modules/SingleMultiSource.cmake
@@ -190,7 +190,7 @@ macro(llvm_multisource)
     set(_target ${_LMARG_PREFIX}${PROG})
     llvm_test_executable(${_target} ${sources})
     target_include_directories(${_target}
-      PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+      PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} "${LLVM_TEST_SUITE_DIR}/include")
     if(_LMARG_TARGET_VAR)
       set(${_LMARG_TARGET_VAR} ${_target})
     endif()

--- a/include/_builtin_common.h
+++ b/include/_builtin_common.h
@@ -1,0 +1,29 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for compiler-defined builtin functions       //
+// corresponding to secure/_common.h functions                         //
+//                                                                     //
+// These are given in the order they appear in clang's Builtins.def.   //
+// Functions that do not appear can not have checked interfaces        //
+// defined.                                                            //
+//                                                                     //
+// These are based on the types as declared within clang               //
+// and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#ifndef __has_builtin
+#define _undef__has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_object_size)
+_Unchecked
+size_t __builtin_object_size(const void* obj, int i);
+#endif
+
+#ifdef _undef__has_builtin
+#undef _undef__has_builtin
+#undef __has_builtin
+#endif

--- a/include/_builtin_stdio_checked.h
+++ b/include/_builtin_stdio_checked.h
@@ -1,0 +1,63 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for compiler-defined builtin functions       //
+// corresponding to stdio.h functions                                  //
+//                                                                     //
+// These are given in the order they appear in clang's Builtins.def.   //
+// Functions that do not appear can not have checked interfaces        //
+// defined.                                                            //
+//                                                                     //
+// These are based on the types as declared within clang               //
+// and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include "_builtin_common.h"
+
+#ifndef __has_builtin
+#define _undef__has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin___snprintf_chk) || defined(__GNUC__)
+extern _Unchecked
+int __snprintf_chk(char * __restrict s : count(n),
+                          size_t n,
+                          int flag,
+                          size_t obj_size,
+                          const char * __restrict format,
+                          ...);
+
+_Unchecked
+int __builtin___snprintf_chk(char * restrict s : count(n),
+                             size_t n,
+                             int flag,
+                             size_t obj_size,
+                             const char * restrict format,
+                             ...);
+#endif
+
+
+#if __has_builtin(__builtin___vsnprintf_chk) || defined(__GNUC__)
+extern _Unchecked
+int __vsnprintf_chk(char * __restrict s : count(n),
+                           size_t n,
+                           int flag,
+                           size_t obj_size,
+                           const char * __restrict format,
+                           va_list);
+
+_Unchecked
+int __builtin___vsnprintf_chk(char * restrict s : count(n),
+                              size_t n,
+                              int flag,
+                              size_t obj_size,
+                              const char * restrict format,
+                              va_list arg);
+#endif
+
+#ifdef _undef__has_builtin
+#undef _undef__has_builtin
+#undef __has_builtin
+#endif

--- a/include/_builtin_string_checked.h
+++ b/include/_builtin_string_checked.h
@@ -1,0 +1,70 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for compiler-defined builtin functions       //
+// corresponding to string.h functions                                 //
+//                                                                     //
+// These are given in the order they appear in clang's Builtins.def.   //
+// Functions that do not appear can not have checked interfaces        //
+// defined.                                                            //
+//                                                                     //
+// These are based on the types as declared within clang               //
+// and https://gcc.gnu.org/onlinedocs/gcc/Object-Size-Checking.html    //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include "_builtin_common.h"
+
+#ifndef __has_builtin
+#define _undef__has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#pragma BOUNDS_CHECKED OFF
+
+#if __has_builtin(__builtin___memcpy_chk) || defined(__GNUC__)
+_Unchecked
+void *__builtin___memcpy_chk(void * restrict dest : byte_count(n),
+                             const void * restrict src : byte_count(n),
+                             size_t n,
+                             size_t obj_size) : bounds(dest, (char *) dest + n);
+#endif
+
+#if __has_builtin(__builtin__memmove_chk) || defined(__GNUC__)
+_Unchecked
+void *__builtin__memmove_chk(void * restrict dest : byte_count(n),
+                             const void * restrict src : byte_count(n),
+                             size_t n,
+                             size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#if __has_builtin(__builtin__memset_chk) || defined(__GNUC__)
+_Unchecked
+void *__builtin__memset_chk(void * s : byte_count(n),
+                            int c,
+                            size_t n,
+                            size_t obj_size) : bounds(s, (char *) s + n);
+#endif
+
+#if __has_builtin(__builtin___strncat_chk) || defined(__GNUC__)
+_Unchecked
+char *__builtin___strncat_chk(char * restrict dest : count(n),
+                              const char * restrict src : count(n),
+                              size_t n,
+                              size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#if __has_builtin(__builtin___strncpy_chk) || defined(__GNUC__)
+_Unchecked
+char *__builtin___strncpy_chk(char * restrict dest : count(n),
+                              const char * restrict src : count(n),
+                              size_t n,
+                              size_t obj_size) : bounds(dest, (char *)dest + n);
+#endif
+
+#pragma BOUNDS_CHECKED ON
+
+#ifdef _undef__has_builtin
+#undef _undef__has_builtin
+#undef __has_builtin
+#endif

--- a/include/fenv_checked.h
+++ b/include/fenv_checked.h
@@ -1,0 +1,20 @@
+//--------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in fenv.h that                //
+// take pointer arguments.                                            //
+//                                                                    //
+// These are listed in the same order that they occur in the C11      //
+// specification.                                                     //
+////////////////////////////////////////////////////////////////////////
+
+#include <fenv.h>
+
+#pragma BOUNDS_CHECKED ON
+
+int fesetexceptflag(const fexcept_t *flagp : itype(_Ptr<const fexcept_t>),
+                    int excepts);
+int fegetenv(fenv_t *envp : itype(_Ptr<fenv_t>));
+int feholdexcept(fenv_t *envp : itype(_Ptr<fenv_t>));
+int fesetenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
+int feupdateenv(const fenv_t *envp : itype(_Ptr<const fenv_t>));
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/inttypes_checked.h
+++ b/include/inttypes_checked.h
@@ -1,0 +1,31 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in inttypes.h that             //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <stddef.h> // define wchar_t for wcstoimax and wcstoumax
+#include <inttypes.h>
+
+#pragma BOUNDS_CHECKED ON
+
+intmax_t strtoimax(const char * restrict nptr,
+                   char ** restrict endptr : itype(restrict _Ptr<char *>),
+                   int base);
+uintmax_t strtoumax(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>),
+                    int base);
+
+intmax_t wcstoimax(const wchar_t * restrict nptr,
+                   wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                   int base);
+uintmax_t wcstoumax(const wchar_t * restrict nptr,
+                    wchar_t ** restrict endptr : itype(restrict _Ptr<wchar_t *>),
+                    int base);
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/math_checked.h
+++ b/include/math_checked.h
@@ -1,0 +1,34 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <math.h>
+
+#pragma BOUNDS_CHECKED ON
+
+double frexp(double value, int *exp : itype(_Ptr<int>));
+float frexpf(float value, int *exp : itype(_Ptr<int>));
+long double frexpl(long double value, int *exp : itype(_Ptr<int>));
+
+double modf(double value, double *iptr : itype(_Ptr<double>));
+float modff(float value, float *iptr : itype(_Ptr<float>));
+long double modfl(long double value,
+                  long double *iptr : itype(_Ptr<long double>));
+
+double remquo(double x, double y, int *quo : itype(_Ptr<int>));
+float remquof(float x, float y, int *quo : itype(_Ptr<int>));
+long double remquol(long double x, long double y, int *quo : itype(_Ptr<int>));
+
+#pragma BOUNDS_CHECKED OFF
+
+// TODO: strings
+// double nan(const char *t);
+// float nanf(const char *t);
+// long double nanf(const char *t);

--- a/include/signal_checked.h
+++ b/include/signal_checked.h
@@ -1,0 +1,17 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for a functions in signal.h that             //
+// take pointer arguments.                                             //
+/////////////////////////////////////////////////////////////////////////
+
+#include <signal.h>
+
+#pragma BOUNDS_CHECKED ON
+
+_Unchecked
+void (*signal(int sig,
+              void ((*func)(int)) :
+                itype(_Ptr<void (int)>) // bound-safe interface for func
+              ) : itype(_Ptr<void (int)>) // bounds-safe interface for signal return
+     )(int);
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/stdchecked.h
+++ b/include/stdchecked.h
@@ -1,0 +1,11 @@
+#ifndef __STDCHECKED_H
+#define __STDCHECKED_H
+
+#define ptr _Ptr
+#define array_ptr _Array_ptr
+#define checked _Checked
+#define unchecked _Unchecked
+#define where _Where
+#define dynamic_check _Dynamic_check
+
+#endif /* __STDCHECKED_H */

--- a/include/stdio_checked.h
+++ b/include/stdio_checked.h
@@ -1,0 +1,146 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in math.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+//                                                                     //
+// TODO: Better Support for _FORTIFY_SOURCE > 0                        //
+/////////////////////////////////////////////////////////////////////////
+
+#include <stdio.h>
+
+#pragma BOUNDS_CHECKED ON
+
+// TODO: handle strings
+// int remove(const char *name);
+// int rename(const char *from, const char *to);
+FILE *tmpfile(void) : itype(_Ptr<FILE>);
+// TODO: handle strings
+// char *tmpnam(char *source);
+int fclose(FILE *stream : itype(_Ptr<FILE>));
+int fflush(FILE *stream : itype(_Ptr<FILE>));
+_Unchecked
+FILE *fopen(const char * restrict filename,
+            const char * restrict mode) : itype(_Ptr<FILE>);
+_Unchecked
+FILE *freopen(const char * restrict filename,
+              const char * restrict mode,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  itype(_Ptr<FILE>);
+
+void setbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(BUFSIZ));
+int setvbuf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            char * restrict buf : count(size),
+            int mode, size_t size);
+
+//
+// TODO: printing and scanning functions are still mostly
+// unchecked because of the use of varargs.
+// * There may not be enough arguments for the format string.
+// * Any pointer arguments may not meet the requirements of the
+//  format string.
+//
+_Unchecked
+int fprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format, ...);
+_Unchecked
+int fscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+           const char * restrict format, ...);
+// TODO: handle strings
+// int printf(const char * restrict format, ...);
+// int scanf(const char * restrict format, ...);
+
+// OMITTED INTENTIONALLY:
+// sprintf cannot be made checked.  It is missing the bounds
+// for the output buffer.
+// int sprintf(char * restrict s,
+//            const char * restrict format, ...);
+//
+// TODO: handle strings
+// int sscanf(const char * restrict s,
+//            const char * restrict format, ...);
+// TODO: Apple System Headers Support
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
+_Unchecked
+int snprintf(char * restrict s : count(n), size_t n,
+             const char * restrict format, ...);
+#endif
+
+_Unchecked
+int vfprintf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+             const char * restrict format,
+             va_list arg);
+_Unchecked
+int vfscanf(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            const char * restrict format,
+            va_list arg);
+
+// TODO: handle strings
+// int vprintf(const char * restrict format,
+//             va_list arg);
+// int vscanf(const char * restrict format,
+//            va_list arg);
+// TODO: Apple System Headers Support
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
+_Unchecked
+int vsnprintf(char * restrict s : count(n), size_t n,
+              const char * restrict format,
+              va_list arg);
+#endif
+// OMITTED INTENTIONALLY:
+// vsprintf cannot be made checked. it is missing the bounds
+// for the output buffer.
+// int vsprintf(char * restrict s,
+//             const char * restrict format,
+//             va_list arg);
+// TODO: handle strings
+// int vsscanf(const char * restrict s,
+//            const char * restrict format,
+//            va_list arg);
+
+int fgetc(FILE *stream : itype(_Ptr<FILE>));
+_Unchecked
+char *fgets(char * restrict s : count(n), int n,
+            FILE * restrict stream : itype(restrict _Ptr<FILE>)) :
+  bounds(s, s + n);
+_Unchecked
+int fputs(const char * restrict s,
+          FILE * restrict stream : itype(restrict _Ptr<FILE>));
+int getc(FILE *stream : itype(_Ptr<FILE>));
+int putc(int c, FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// int puts(const char *str);
+int ungetc(int c, FILE *stream : itype(_Ptr<FILE>));
+
+size_t fread(void * restrict pointer : byte_count(size * nmemb),
+             size_t size, size_t nmemb,
+             FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+size_t fwrite(const void * restrict pointer : byte_count(size * nmemb),
+              size_t size, size_t nmemb,
+              FILE * restrict stream : itype(restrict _Ptr<FILE>));
+
+int fgetpos(FILE * restrict stream : itype(restrict _Ptr<FILE>),
+            fpos_t * restrict pos : itype(restrict _Ptr<fpos_t>));
+
+int fseek(FILE *stream : itype(_Ptr<FILE>), long int offset, int whence);
+int fsetpos(FILE *stream : itype(_Ptr<FILE>),
+            const fpos_t *pos :  itype(_Ptr<const fpos_t>));
+
+long int ftell(FILE *stream : itype(_Ptr<FILE>));
+void rewind(FILE *stream : itype(_Ptr<FILE>));
+
+void clearerr(FILE *stream : itype(_Ptr<FILE>));
+int feof(FILE *stream : itype(_Ptr<FILE>));
+int ferror(FILE *stream : itype(_Ptr<FILE>));
+// TODO: strings
+// void perror(const char *s);
+
+#include "_builtin_stdio_checked.h"
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/stdlib_checked.h
+++ b/include/stdlib_checked.h
@@ -1,0 +1,107 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in stdlib.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+#include <stdlib.h>
+
+#pragma BOUNDS_CHECKED ON
+
+// TODO: strings
+// double atof(const char *s);
+// int atoi(const char *s);
+// long int atol(const char *s);
+// long long int atoll(const char *s);
+
+_Unchecked
+double strtod(const char * restrict nptr,
+              char ** restrict endptr : itype(restrict _Ptr<char *>));
+_Unchecked
+float strtof(const char * restrict nptr,
+             char ** restrict endptr : itype(restrict _Ptr<char *>));
+_Unchecked
+long double strtold(const char * restrict nptr,
+                    char ** restrict endptr : itype(restrict _Ptr<char *>));
+
+_Unchecked
+long int strtol(const char * restrict nptr,
+                char ** restrict endptr : itype(restrict _Ptr<char *>),
+                int base);
+_Unchecked
+long long int strtoll(const char * restrict nptr,
+                      char ** restrict endptr : itype(restrict _Ptr<char *>),
+                      int base);
+_Unchecked
+unsigned long int strtoul(const char * restrict nptr,
+                          char ** restrict endptr :
+                            itype(restrict _Ptr<char *>),
+                          int base);
+
+_Unchecked
+unsigned long long int strtoull(const char * restrict nptr,
+                                char ** restrict endptr:
+                                   itype(restrict _Ptr<char *>),
+                                int base);
+
+// TODO: express alignment constraints once where clauses have been added.
+void *aligned_alloc(size_t alignment, size_t size) : byte_count(size);
+void *calloc(size_t nmemb, size_t size) : byte_count(nmemb * size);
+void free(void *pointer : itype(_Ptr<void>));
+void *malloc(size_t size) : byte_count(size);
+void *realloc(void *pointer  : itype(_Ptr<void>), size_t size) : byte_count(size);
+
+// TODO: strings
+// char *getenv(const char *n);
+
+int atexit(void ((*func)(void)) : itype(_Ptr<void (void)>));
+int atquick_exit(void ((*func)(void)) : itype(_Ptr<void (void)>));
+
+// TODO: strings
+// int system(const char *s);
+
+// TODO: compar needs to have an itype that has bounds
+// on parameters based on size.  Currently we are requiring that
+// bounds in parameters lists be closed with respect to variables
+// in the parameter list.
+void *bsearch(const void *key : byte_count(size),
+              const void *base : byte_count(nmemb * size),
+              size_t nmemb, size_t size,
+              int ((*compar)(const void *, const void *)) :
+                itype(_Ptr<int(_Ptr<const void>, _Ptr<const void>)>)) :
+                byte_count(size);
+
+// TODO: compar needs to have an itype that has bounds
+// on parameters based on size.  Currently we are requiring that
+// types be closed.
+void qsort(void *base : byte_count(nmemb * size),
+           size_t nmemb, size_t size,
+           int ((*compar)(const void *, const void *)) :
+             itype(_Ptr<int (_Ptr<const void>, _Ptr<const void>)>));
+
+int mblen(const char *s : count(n), size_t n);
+
+int mbtowc(wchar_t * restrict output : itype(restrict _Ptr<wchar_t>),
+           const char * restrict input : count(n),
+           size_t n);
+
+// MB_CUR_MAX is a macro that becomes a function call, so is banned
+// in bounds annotations. 
+// 
+// int wctomb(char *s : count(MB_CUR_MAX), wchar_t wc);
+
+_Unchecked
+size_t mbstowcs(wchar_t * restrict pwcs : count(n),
+                const char * restrict s,
+                size_t n);
+
+_Unchecked
+size_t wcstombs(char * restrict output : count(n),
+                const wchar_t * restrict pwcs,
+                size_t n);
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/string_checked.h
+++ b/include/string_checked.h
@@ -1,0 +1,102 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in string.h that               //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+//                                                                     //
+// TODO: Better Support for _FORTIFY_SOURCE > 0                        //
+/////////////////////////////////////////////////////////////////////////
+#include <string.h>
+
+// TODO: Apple System Headers Support
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
+_Unchecked
+void *memcpy(void * restrict dest : byte_count(n),
+             const void * restrict src : byte_count(n),
+             size_t n) : bounds(dest, (char *) dest + n);
+
+void *memmove(void * restrict dest : byte_count(n),
+              const void * restrict src : byte_count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+#endif
+// TODO: strings
+// char *strcpy(char * restrict dest,
+//              const char * restrict src);
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on s1.
+// char *strcpy(char * restrict s1,
+//              const char * restrict s2);
+
+// TODO: Apple System Headers Support
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
+_Unchecked
+char *strncpy(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+#endif
+
+// OMITTED INTENTIONALLY: this cannot be made checked.
+// There is no bound on dest.
+// char *strcat(char * restrict dest,
+//              const char * restrict src);
+
+// TODO: Apple System Headers Support
+#ifndef __APPLE__
+_Unchecked
+char *strncat(char * restrict dest : count(n),
+              const char * restrict src : count(n),
+              size_t n) : bounds(dest, (char *)dest + n);
+#endif
+
+#pragma BOUNDS_CHECKED ON
+
+int memcmp(const void *src1 : byte_count(n), const void *src2 : byte_count(n),
+           size_t n);
+
+// TODO: strings
+// int strcmp(const char *src1, const char *src2);
+// int strcoll(const char *src1, const char *src2);
+
+//int strncmp(const char *src : count(n), const char *s2 : count(n), size_t n);
+_Unchecked
+size_t strxfrm(char * restrict dest : count(n),
+               const char * restrict src,
+               size_t n);
+
+#pragma BOUNDS_CHECKED OFF
+_Unchecked
+void *memchr(const void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char*) s + n);
+#pragma BOUNDS_CHECKED ON
+
+// TODO: strings
+// char *strchr(const char *s, int c);
+// size_t strcspn(const char *s1, const char *s2);
+// char *strpbrk(const char *s1, const char *s2);
+// char *strrchr(const char *s, int c);
+// size_t strspn(const char *s1, const char *s2);
+// char *strstr(const char *s1, const char *s2);
+// char *strtok(char * restrict s1,
+//              const char * restrict s2);
+
+// TODO: Apple System Headers Support
+#if !defined (__APPLE__) && _FORTIFY_SOURCE > 0
+#pragma BOUNDS_CHECKED OFF
+_Unchecked
+void *memset(void *s : byte_count(n), int c, size_t n) :
+  bounds(s, (char *) s + n);
+#pragma BOUNDS_CHECKED ON
+#endif
+
+// TODO: strings
+// char *strerror(int errnum);
+// size_t strlen(const char *s);
+
+#include "_builtin_string_checked.h"
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/threads_checked.h
+++ b/include/threads_checked.h
@@ -1,0 +1,66 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in threads.h that              //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+/////////////////////////////////////////////////////////////////////////
+
+#ifdef _CHECKEDC_MOCKUP_THREADS
+// C implementations may not support the C11 threads package or even the
+// macro that says C11 threads are not supported.  This mocks up
+// the types needed by threads so that we can test that the declarations
+// below compile.
+typedef struct __once_flag_struct once_flag;
+typedef struct __cnd_struct cnd_t;
+typedef struct __mtx_struct mtx_t;
+typedef struct __thread_struct thrd_t;
+typedef int (*thrd_start_t)(void *);
+typedef struct __thread_specific_storage_struct tss_t;
+typedef void (tss_dtor_t)(void *);
+struct timespec;
+#else
+#include <threads.h>
+#endif
+
+#pragma BOUNDS_CHECKED ON
+
+void call_once(once_flag *flag : itype(_Ptr<once_flag>),
+               void ((*fn)(void)) : itype(_Ptr<void (void)>));
+
+int cnd_broadcast(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_destroy(cnd_t *condition : itype(_Ptr<cnd_t>));
+void cnd_init(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_signal(cnd_t *condition : itype(_Ptr<cnd_t>));
+int cnd_timedwait(cnd_t *restrict cond : itype(restrict _Ptr<cnd_t>),
+                  mtx_t *restrict mutex: itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict spec :
+                    itype(restrict _Ptr<const struct timespec>));
+int cnd_wait(cnd_t *condition : itype(_Ptr<cnd_t>),
+             mtx_t *mutex : itype(_Ptr<mtx_t>));
+void mtx_destroy(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_init(mtx_t *mutex : itype(_Ptr<mtx_t>), int type);
+int mtx_lock(mtx_t *mutex : itype(_Ptr<mtx_t>));
+int mtx_timedlock(mtx_t *restrict mutex : itype(restrict _Ptr<mtx_t>),
+                  const struct timespec *restrict ts :
+                    itype(restrict _Ptr<const struct timespec>));
+int mtx_trylock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+int mtx_unlock(mtx_t *mtex : itype(_Ptr<mtx_t>));
+
+int thrd_create(thrd_t *thr : itype(_Ptr<thrd_t>),
+                thrd_start_t func :
+                  itype(_Ptr<int (void * : itype(_Ptr<void>))>),
+                void *arg : itype(_Ptr<void>));
+int thrd_join(thrd_t thr, int *res : itype(_Ptr<int>));
+int thrd_sleep(const struct timespec *duration :
+                 itype(_Ptr<const struct timespec>),
+               struct timespec *remaining : itype(_Ptr<struct timespec>));
+int tss_create(tss_t *key : itype(_Ptr<tss_t>),
+               tss_dtor_t dtor :
+                 itype(_Ptr<void (void * : itype(_Ptr<void>))>));
+// Casting the Ptr<void> returned by tss_get to a specific type will be an
+// unchecked operation.
+void *tss_get(tss_t key) : itype(_Ptr<void>);
+int tss_set(tss_t key, void *value : itype(_Ptr<void>));
+
+#pragma BOUNDS_CHECKED OFF

--- a/include/time_checked.h
+++ b/include/time_checked.h
@@ -1,0 +1,31 @@
+//---------------------------------------------------------------------//
+// Bounds-safe interfaces for functions in time.h that                 //
+// take pointer arguments.                                             //
+//                                                                     //
+// These are listed in the same order that they occur in the C11       //
+// specification.                                                      //
+//                                                                     //
+// TODO: revise string types after support for pointers to             //
+// null-terminated arrays is added to C.                               //
+/////////////////////////////////////////////////////////////////////////
+
+#include <time.h>
+
+#pragma BOUNDS_CHECKED ON
+
+time_t mktime(struct tm *timeptr : itype(_Ptr<struct tm>));
+int timespec_get(struct timespec *ts : itype(_Ptr<struct timespec>),
+                 int base);
+char *asctime(const struct tm *timeptr : itype(_Ptr<const struct tm>));
+char *ctime(const time_t *timer : itype(_Ptr<const time_t>));
+struct tm *gmtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+struct tm *localtime(const time_t *timer : itype(_Ptr<const time_t>)) :
+  itype(_Ptr<struct tm>);
+size_t strftime(char * restrict output : count(maxsize),
+                size_t maxsize,
+                const char * restrict format,
+                const struct tm * restrict timeptr :
+                   itype(restrict _Ptr<const struct tm>));
+
+#pragma BOUNDS_CHECKED OFF


### PR DESCRIPTION
This reverts commit 7e961cdde1c178de3db111209d7ac1eaf14ef6f5.

The commit caused automated testing which relies on LNT makefiles to break.  These need to be updated to find the new Checked C include file directory.   I thought I understood how to get the makefile system to use additional include directories, but I was wrong.
