### PR TITLE
Convert Olden/voronoi benchmark

### DIFF
--- a/MultiSource/Benchmarks/Olden/voronoi/args.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/args.c
@@ -1,7 +1,9 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <stdlib_checked.h>
+#include <stdio_checked.h>
+
+#pragma BOUNDS_CHECKED ON
 
 extern int NumNodes,NDim;
 
@@ -15,7 +17,8 @@ int mylog(int num) {
   return j;
 } 
 
-int dealwithargs(int argc, char *argv[]) {
+_Unchecked
+int dealwithargs(int argc, _Array_ptr<char *> argv : count(argc)) {
   int size;
 
   if (argc > 3)

--- a/MultiSource/Benchmarks/Olden/voronoi/defines.h
+++ b/MultiSource/Benchmarks/Olden/voronoi/defines.h
@@ -9,7 +9,7 @@ typedef unsigned long      uptrint;
 
 struct edge_rec {
   _Ptr<struct VERTEX> v;
-  _Ptr<struct edge_rec> next;
+  _Array_ptr<struct edge_rec> next : count(4);
   long wasseen;
   _Array_ptr<void> Buffer;
 };

--- a/MultiSource/Benchmarks/Olden/voronoi/defines.h
+++ b/MultiSource/Benchmarks/Olden/voronoi/defines.h
@@ -1,28 +1,30 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
-#include <math.h>
+#include <math_checked.h>
+
+#pragma BOUNDS_CHECKED ON
 
 typedef int BOOLEAN;
 typedef unsigned long      uptrint;
 
 struct edge_rec {
-  struct VERTEX *v;
-  struct edge_rec *next;
+  _Ptr<struct VERTEX> v;
+  _Ptr<struct edge_rec> next;
   long wasseen;
-  void *Buffer;
+  _Array_ptr<void> Buffer;
 };
 
 
 struct get_point {
-  struct VERTEX *v;
+  _Ptr<struct VERTEX> v;
   double curmax;
   int seed;
 };
 
 
-typedef struct edge_rec *EDGE_PTR;
-typedef struct VERTEX *VERTEX_PTR;
-typedef struct edge_rec *QUAD_EDGE;
+typedef _Ptr<struct edge_rec> EDGE_PTR;
+typedef _Ptr<struct VERTEX> VERTEX_PTR;
+typedef _Array_ptr<struct edge_rec> QUAD_EDGE;
   
 struct VEC2 {
   double x,y;
@@ -32,18 +34,18 @@ struct VEC2 {
 
 struct VERTEX {
   struct VEC2 v;
-  struct VERTEX *left, *right;
+  _Ptr<struct VERTEX> left, right;
 };
 
 
 typedef struct {
-  QUAD_EDGE left, right;
+  QUAD_EDGE left : count(4), right : count(4);
 } EDGE_PAIR;
 
 
 struct EDGE_STACK {
     int ptr;
-    QUAD_EDGE *elts ;
+    _Array_ptr<QUAD_EDGE> elts : count(stack_size * 2);
     int stack_size;
 };
 
@@ -76,42 +78,43 @@ struct EDGE_STACK {
 #define rotinv(a) ((QUAD_EDGE) ( (((uptrint) (a) + 3*SIZE) & ANDF) | ((uptrint) (a) & ~ANDF) ))
 #define base(a) ((QUAD_EDGE) ((uptrint a) & ~ANDF))
 
-QUAD_EDGE alloc_edge();
-void free_edge(QUAD_EDGE e);
-QUAD_EDGE makeedge();
-void splice();
-void swapedge();
-void deleteedge();
-QUAD_EDGE build_delaunay_triangulation();
+QUAD_EDGE alloc_edge(void) : count(4);
+void free_edge(QUAD_EDGE e : count(4));
+QUAD_EDGE makeedge(VERTEX_PTR origin, VERTEX_PTR destination) : count(4);
+void splice(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4));
+void swapedge(QUAD_EDGE e : count(4));
+void deleteedge(QUAD_EDGE e : count(4));
+QUAD_EDGE build_delaunay_triangulation(VERTEX_PTR tree, VERTEX_PTR extra) : count(4);
 EDGE_PAIR build_delaunay(VERTEX_PTR tree, VERTEX_PTR extra);
-EDGE_PAIR do_merge(QUAD_EDGE ldo, QUAD_EDGE ldi, QUAD_EDGE rdi, QUAD_EDGE rdo);
-QUAD_EDGE connect_left();
-QUAD_EDGE connect_right();
+EDGE_PAIR do_merge(QUAD_EDGE ldo : count(4), QUAD_EDGE ldi : count(4), QUAD_EDGE rdi : count(4), QUAD_EDGE rdo : count(4));
+QUAD_EDGE connect_left(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4);
+QUAD_EDGE connect_right(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4);
 
 int myrandom(int seed);
-void zero_seen();
-QUAD_EDGE pop_edge();
+void zero_seen(_Ptr<struct EDGE_STACK> my_stack, QUAD_EDGE edge : count(4));
+QUAD_EDGE pop_edge(_Ptr<struct EDGE_STACK> x) : count(4);
 
 #define drand(seed) (((double) (seed=myrandom(seed))) / (double) 2147483647)
 
-extern VERTEX_PTR *vp ;
-extern struct VERTEX *va ;
-extern EDGE_PTR *next ;
-extern VERTEX_PTR *org ;
+extern _Ptr<VERTEX_PTR> vp ;
+extern _Array_ptr<struct VERTEX> va ;
+extern _Ptr<EDGE_PTR> next ;
+extern _Ptr<VERTEX_PTR> org ;
 extern int num_vertices, num_edgeparts, stack_size ;
 extern int to_lincoln , to_off, to_3d_out, to_color , voronoi , delaunay , interactive , ahost ;
-extern char *see;
+extern _Array_ptr<char> see;
 extern int NumNodes, NDim;
 
 
-void push_ring(struct EDGE_STACK *stack, QUAD_EDGE edge);
-void push_edge(struct EDGE_STACK *stack, QUAD_EDGE edge);
+void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4));
+void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4));
 BOOLEAN ccw(VERTEX_PTR a, VERTEX_PTR b, VERTEX_PTR c);
-int dealwithargs(int argc, char *argv[]);
-void output_voronoi_diagram(QUAD_EDGE edge, int nv, struct EDGE_STACK *stack);
+_Unchecked
+int dealwithargs(int argc, _Array_ptr<char *> argv : count(argc));
+void output_voronoi_diagram(QUAD_EDGE edge : count(4), int nv, _Ptr<struct EDGE_STACK> stack);
 struct get_point get_points(int n, double curmax,int i, int seed,
                             int processor, int numnodes);
-struct EDGE_STACK *allocate_stack(int num_vertices);
+_Ptr<struct EDGE_STACK> allocate_stack(int num_vertices);
 
 
 double V2_cprod(struct VEC2 u,struct VEC2 v);
@@ -121,3 +124,5 @@ struct VEC2 V2_sum(struct VEC2 u, struct VEC2 v);
 struct VEC2 V2_sub(struct VEC2 u, struct VEC2 v);
 double V2_magn(struct VEC2 u);
 struct VEC2 V2_cross(struct VEC2 v);
+
+#pragma BOUNDS_CHECKED OFF

--- a/MultiSource/Benchmarks/Olden/voronoi/defines.h
+++ b/MultiSource/Benchmarks/Olden/voronoi/defines.h
@@ -9,7 +9,7 @@ typedef unsigned long      uptrint;
 
 struct edge_rec {
   _Ptr<struct VERTEX> v;
-  _Array_ptr<struct edge_rec> next : count(4);
+  _Array_ptr<struct edge_rec> next : quad_bounds(next);
   long wasseen;
   _Array_ptr<void> Buffer;
 };
@@ -39,7 +39,7 @@ struct VERTEX {
 
 
 typedef struct {
-  QUAD_EDGE left : count(4), right : count(4);
+  QUAD_EDGE left : quad_bounds(left), right : quad_bounds(right);
 } EDGE_PAIR;
 
 
@@ -76,22 +76,24 @@ struct EDGE_STACK {
 #define sym(a) ((QUAD_EDGE) (((uptrint) (a)) ^ 2*SIZE))
 #define rot(a) ((QUAD_EDGE) ( (((uptrint) (a) + 1*SIZE) & ANDF) | ((uptrint) (a) & ~ANDF) ))
 #define rotinv(a) ((QUAD_EDGE) ( (((uptrint) (a) + 3*SIZE) & ANDF) | ((uptrint) (a) & ~ANDF) ))
-#define base(a) ((QUAD_EDGE) ((uptrint a) & ~ANDF))
+#define base(a) ((QUAD_EDGE) (((uptrint) (a)) & ~ANDF))
+
+#define quad_bounds(a) bounds(base(a), base(a) + 4)
 
 QUAD_EDGE alloc_edge(void) : count(4);
-void free_edge(QUAD_EDGE e : count(4));
+void free_edge(QUAD_EDGE e : quad_bounds(e));
 QUAD_EDGE makeedge(VERTEX_PTR origin, VERTEX_PTR destination) : count(4);
-void splice(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4));
-void swapedge(QUAD_EDGE e : count(4));
-void deleteedge(QUAD_EDGE e : count(4));
+void splice(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b));
+void swapedge(QUAD_EDGE e : quad_bounds(e));
+void deleteedge(QUAD_EDGE e : quad_bounds(e));
 QUAD_EDGE build_delaunay_triangulation(VERTEX_PTR tree, VERTEX_PTR extra) : count(4);
 EDGE_PAIR build_delaunay(VERTEX_PTR tree, VERTEX_PTR extra);
-EDGE_PAIR do_merge(QUAD_EDGE ldo : count(4), QUAD_EDGE ldi : count(4), QUAD_EDGE rdi : count(4), QUAD_EDGE rdo : count(4));
-QUAD_EDGE connect_left(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4);
-QUAD_EDGE connect_right(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4);
+EDGE_PAIR do_merge(QUAD_EDGE ldo : quad_bounds(ldo), QUAD_EDGE ldi : quad_bounds(ldi), QUAD_EDGE rdi : quad_bounds(rdi), QUAD_EDGE rdo : quad_bounds(rdo));
+QUAD_EDGE connect_left(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b)) : count(4);
+QUAD_EDGE connect_right(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b)) : count(4);
 
 int myrandom(int seed);
-void zero_seen(_Ptr<struct EDGE_STACK> my_stack, QUAD_EDGE edge : count(4));
+void zero_seen(_Ptr<struct EDGE_STACK> my_stack, QUAD_EDGE edge : quad_bounds(edge));
 QUAD_EDGE pop_edge(_Ptr<struct EDGE_STACK> x) : count(4);
 
 #define drand(seed) (((double) (seed=myrandom(seed))) / (double) 2147483647)
@@ -106,12 +108,12 @@ extern _Array_ptr<char> see;
 extern int NumNodes, NDim;
 
 
-void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4));
-void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4));
+void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : quad_bounds(edge));
+void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : quad_bounds(edge));
 BOOLEAN ccw(VERTEX_PTR a, VERTEX_PTR b, VERTEX_PTR c);
 _Unchecked
 int dealwithargs(int argc, _Array_ptr<char *> argv : count(argc));
-void output_voronoi_diagram(QUAD_EDGE edge : count(4), int nv, _Ptr<struct EDGE_STACK> stack);
+void output_voronoi_diagram(QUAD_EDGE edge : quad_bounds(edge), int nv, _Ptr<struct EDGE_STACK> stack);
 struct get_point get_points(int n, double curmax,int i, int seed,
                             int processor, int numnodes);
 _Ptr<struct EDGE_STACK> allocate_stack(int num_vertices);

--- a/MultiSource/Benchmarks/Olden/voronoi/newvor.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/newvor.c
@@ -96,7 +96,9 @@ VERTEX_PTR get_low(register VERTEX_PTR tree)
 
 EDGE_PAIR build_delaunay(VERTEX_PTR tree, VERTEX_PTR extra)
 {
-    QUAD_EDGE a = NULL, b = NULL, c = NULL, ldo = NULL, rdi = NULL, ldi = NULL, rdo = NULL;
+    QUAD_EDGE a : count(4) = NULL, b : count(4) = NULL, c : count(4) = NULL;
+    QUAD_EDGE ldo : count(4) = NULL, rdi : count(4) = NULL;
+    QUAD_EDGE ldi : count(4) = NULL, rdo : count(4) = NULL;
     EDGE_PAIR retval;
     register VERTEX_PTR maxx = NULL, minx = NULL;
     VERTEX_PTR s1 = NULL, s2 = NULL, s3 = NULL;
@@ -154,7 +156,7 @@ return retval;
 /****************************************************************/
 /*	Quad-edge storage allocation                            */
 /****************************************************************/
-QUAD_EDGE next_edge, avail_edge;
+QUAD_EDGE next_edge : count(4) = NULL, avail_edge : count(4) = NULL;
 
 #define NYL NULL
 
@@ -337,7 +339,7 @@ void swapedge(QUAD_EDGE e : count(4))
 /****************************************************************/
 /*#define valid(l) ccw(orig(basel), dest(l), dest(basel))*/
 
-int valid(QUAD_EDGE l, QUAD_EDGE basel)
+int valid(QUAD_EDGE l : count(4), QUAD_EDGE basel : count(4))
 {
   register VERTEX_PTR t1 = NULL, t2 = NULL, t3 = NULL;
 

--- a/MultiSource/Benchmarks/Olden/voronoi/newvor.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/newvor.c
@@ -21,10 +21,10 @@ int NumNodes, NDim;
 
 int flag;
 
-QUAD_EDGE connect_left(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4)
+QUAD_EDGE connect_left(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b)) : count(4)
 {
   VERTEX_PTR t1 = NULL, t2 = NULL;
-  register QUAD_EDGE ans : count(4) = NULL, lnexta : count(4) = NULL;
+  register QUAD_EDGE ans : quad_bounds(ans) = NULL, lnexta : quad_bounds(lnexta) = NULL;
 
 /*printf("begin connect_left\n");*/
   t1=dest(a);
@@ -37,10 +37,10 @@ QUAD_EDGE connect_left(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4
   return(ans);
 }
 
-QUAD_EDGE connect_right(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(4)
+QUAD_EDGE connect_right(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b)) : count(4)
 {
   VERTEX_PTR t1 = NULL, t2 = NULL;
-  register QUAD_EDGE ans : count(4) = NULL, oprevb : count(4) = NULL;
+  register QUAD_EDGE ans : quad_bounds(ans) = NULL, oprevb : quad_bounds(oprevb) = NULL;
 
 /*printf("begin connect_right\n");*/
   t1=dest(a);
@@ -53,7 +53,7 @@ QUAD_EDGE connect_right(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4)) : count(
   return(ans);
 }
 
-void deleteedge(QUAD_EDGE e : count(4))
+void deleteedge(QUAD_EDGE e : quad_bounds(e))
      /*disconnects e from the rest of the structure and destroys it. */
 {
   QUAD_EDGE f = NULL;
@@ -96,9 +96,9 @@ VERTEX_PTR get_low(register VERTEX_PTR tree)
 
 EDGE_PAIR build_delaunay(VERTEX_PTR tree, VERTEX_PTR extra)
 {
-    QUAD_EDGE a : count(4) = NULL, b : count(4) = NULL, c : count(4) = NULL;
-    QUAD_EDGE ldo : count(4) = NULL, rdi : count(4) = NULL;
-    QUAD_EDGE ldi : count(4) = NULL, rdo : count(4) = NULL;
+    QUAD_EDGE a : quad_bounds(a) = NULL, b : quad_bounds(b) = NULL, c : quad_bounds(c) = NULL;
+    QUAD_EDGE ldo : quad_bounds(ldo) = NULL, rdi : quad_bounds(rdi) = NULL;
+    QUAD_EDGE ldi : quad_bounds(ldi) = NULL, rdo : quad_bounds(rdo) = NULL;
     EDGE_PAIR retval;
     register VERTEX_PTR maxx = NULL, minx = NULL;
     VERTEX_PTR s1 = NULL, s2 = NULL, s3 = NULL;
@@ -156,7 +156,7 @@ return retval;
 /****************************************************************/
 /*	Quad-edge storage allocation                            */
 /****************************************************************/
-QUAD_EDGE next_edge : count(4) = NULL, avail_edge : count(4) = NULL;
+QUAD_EDGE next_edge : quad_bounds(next_edge) = NULL, avail_edge : quad_bounds(avail_edge) = NULL;
 
 #define NYL NULL
 
@@ -189,7 +189,7 @@ _Array_ptr<void> myalign(int align_size, int alloc_size) : byte_count(alloc_size
 
 
 QUAD_EDGE alloc_edge(void) : count(4) {
-  QUAD_EDGE ans : count(4) = NULL;
+  QUAD_EDGE ans : quad_bounds(ans) = NULL;
 
   if (avail_edge == NYL) {
     ans = (QUAD_EDGE)myalign(4*(sizeof(struct edge_rec)),
@@ -208,7 +208,7 @@ QUAD_EDGE alloc_edge(void) : count(4) {
   return ans;
 }
 
-void free_edge(QUAD_EDGE e : count(4)) {
+void free_edge(QUAD_EDGE e : quad_bounds(e)) {
   e = (QUAD_EDGE) ((uptrint) e ^ ((uptrint) e & ANDF));
   onext(e) = avail_edge;
   avail_edge = e;
@@ -267,7 +267,7 @@ BOOLEAN ccw(VERTEX_PTR a, VERTEX_PTR b, VERTEX_PTR c) {
 /****************************************************************/
 QUAD_EDGE makeedge(VERTEX_PTR origin, VERTEX_PTR destination) : count(4)
 {
-    register QUAD_EDGE temp : count(4) = NULL, ans : count(4) = NULL;
+    register QUAD_EDGE temp : quad_bounds(temp) = NULL, ans : quad_bounds(ans) = NULL;
     temp =  alloc_edge();
     ans = temp;
 
@@ -286,10 +286,10 @@ QUAD_EDGE makeedge(VERTEX_PTR origin, VERTEX_PTR destination) : count(4)
     return(ans);
 }
 
-void splice(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4))
+void splice(QUAD_EDGE a : quad_bounds(a), QUAD_EDGE b : quad_bounds(b))
 {
-    QUAD_EDGE alpha : count(4) = NULL, beta : count(4) = NULL, temp : count(4) = NULL;
-    QUAD_EDGE t1 : count(4) = NULL;
+    QUAD_EDGE alpha : quad_bounds(alpha) = NULL, beta : quad_bounds(beta) = NULL, temp : quad_bounds(temp) = NULL;
+    QUAD_EDGE t1 : quad_bounds(t1) = NULL;
 
     /*printf("begin splice 0x%x,0x%x\n",a,b);*/
     /*dump_quad(a); dump_quad(b);*/
@@ -312,9 +312,9 @@ void splice(QUAD_EDGE a : count(4), QUAD_EDGE b : count(4))
     /*printf("End splice\n");*/
 }
 
-void swapedge(QUAD_EDGE e : count(4))
+void swapedge(QUAD_EDGE e : quad_bounds(e))
 {
-    QUAD_EDGE a : count(4) = NULL, b : count(4) = NULL, syme : count(4) = NULL, lnexttmp : count(4) = NULL;
+    QUAD_EDGE a : quad_bounds(a) = NULL, b : quad_bounds(b) = NULL, syme : quad_bounds(syme) = NULL, lnexttmp : quad_bounds(lnexttmp) = NULL;
     VERTEX_PTR a1 = NULL, b1 = NULL;
     
     /*printf("begin swapedge\n");*/
@@ -339,7 +339,7 @@ void swapedge(QUAD_EDGE e : count(4))
 /****************************************************************/
 /*#define valid(l) ccw(orig(basel), dest(l), dest(basel))*/
 
-int valid(QUAD_EDGE l : count(4), QUAD_EDGE basel : count(4))
+int valid(QUAD_EDGE l : quad_bounds(l), QUAD_EDGE basel : quad_bounds(basel))
 {
   register VERTEX_PTR t1 = NULL, t2 = NULL, t3 = NULL;
 
@@ -352,10 +352,10 @@ int valid(QUAD_EDGE l : count(4), QUAD_EDGE basel : count(4))
   return ccw(t1,t2,t3);
 }
 
-void dump_quad(QUAD_EDGE ptr : count(4))
+void dump_quad(QUAD_EDGE ptr : quad_bounds(ptr))
 {
   int i;
-  QUAD_EDGE j : count(4) = NULL;
+  QUAD_EDGE j : quad_bounds(j) = NULL;
   VERTEX_PTR v = NULL;
 
   ptr = (QUAD_EDGE) ((uptrint) ptr & ~ANDF);
@@ -373,10 +373,10 @@ void dump_quad(QUAD_EDGE ptr : count(4))
 
 
 
-EDGE_PAIR do_merge(QUAD_EDGE ldo : count(4), QUAD_EDGE ldi : count(4), QUAD_EDGE rdi : count(4), QUAD_EDGE rdo : count(4))
+EDGE_PAIR do_merge(QUAD_EDGE ldo : quad_bounds(ldo), QUAD_EDGE ldi : quad_bounds(ldi), QUAD_EDGE rdi : quad_bounds(rdi), QUAD_EDGE rdo : quad_bounds(rdo))
 {
   int rvalid, lvalid;
-  register QUAD_EDGE basel : count(4) = NULL, lcand : count(4) = NULL, rcand : count(4) = NULL, t : count(4) = NULL;
+  register QUAD_EDGE basel : quad_bounds(basel) = NULL, lcand : quad_bounds(lcand) = NULL, rcand : quad_bounds(rcand) = NULL, t : quad_bounds(t) = NULL;
   VERTEX_PTR t1 = NULL, t2 = NULL;
 
 /*printf("merge\n");*/
@@ -576,7 +576,7 @@ _Unchecked
 int main(int argc, _Array_ptr<char *> argv : count(argc)) {
   _Ptr<struct EDGE_STACK> my_stack = NULL;
   struct get_point point, extra;
-  QUAD_EDGE edge : count(4) = NULL;
+  QUAD_EDGE edge : quad_bounds(edge) = NULL;
   int n, retained;
   to_lincoln = to_off = to_3d_out = to_color = 0;
   voronoi = delaunay = 1; interactive = ahost = 0 ;
@@ -678,7 +678,7 @@ QUAD_EDGE pop_edge(_Ptr<struct EDGE_STACK> x) : count(4) {
   return (x)->elts[a];
 }
 
-void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4)) {
+void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : quad_bounds(edge)) {
   register int a;
   /*printf("pushing edge \n");*/
   if (stack->ptr == stack->stack_size) _Unchecked {
@@ -692,8 +692,8 @@ void push_edge(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4)) {
   }
 }
 
-void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4)) {
-    QUAD_EDGE nex : count(4) = NULL;
+void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : quad_bounds(edge)) {
+    QUAD_EDGE nex : quad_bounds(nex) = NULL;
     nex = onext(edge);
     while (nex != edge) {
 	if (seen(nex) == 0) {
@@ -704,9 +704,9 @@ void push_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4)) {
     }
 }
 
-void push_nonzero_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4))
+void push_nonzero_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : quad_bounds(edge))
 {
-  QUAD_EDGE nex : count(4) = NULL;
+  QUAD_EDGE nex : quad_bounds(nex) = NULL;
   nex = onext(edge);
   while (nex != edge) {
     if (seen(nex) != 0) {
@@ -717,7 +717,7 @@ void push_nonzero_ring(_Ptr<struct EDGE_STACK> stack, QUAD_EDGE edge : count(4))
   }
 }
 
-void zero_seen(_Ptr<struct EDGE_STACK> my_stack, QUAD_EDGE edge : count(4))
+void zero_seen(_Ptr<struct EDGE_STACK> my_stack, QUAD_EDGE edge : quad_bounds(edge))
 {
   my_stack->ptr = 0;
   push_nonzero_ring(my_stack, edge);

--- a/MultiSource/Benchmarks/Olden/voronoi/output.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/output.c
@@ -88,9 +88,9 @@ struct VEC2 circle_center(struct VEC2 a, struct VEC2 b, struct VEC2 c)
 
 _Array_ptr<int> earray;
 
-void output_voronoi_diagram(QUAD_EDGE edge : count(4), int nv, _Ptr<struct EDGE_STACK> my_stack)
+void output_voronoi_diagram(QUAD_EDGE edge : quad_bounds(edge), int nv, _Ptr<struct EDGE_STACK> my_stack)
 {
-  QUAD_EDGE nex : count(4) = NULL, prev : count(4) = NULL, snex : count(4) = NULL, sprev : count(4) = NULL;
+  QUAD_EDGE nex : quad_bounds(nex) = NULL, prev : quad_bounds(prev) = NULL, snex : quad_bounds(snex) = NULL, sprev : quad_bounds(sprev) = NULL;
   struct VEC2 cvxvec, center;
   double ln;
   
@@ -103,7 +103,7 @@ void output_voronoi_diagram(QUAD_EDGE edge : count(4), int nv, _Ptr<struct EDGE_
     /*  Plot VD edges with one endpoint at infinity. */
     do {
       struct VEC2 v21,v22,v23;
-      QUAD_EDGE tmp : count(4) = NULL;
+      QUAD_EDGE tmp : quad_bounds(tmp) = NULL;
 
       v21=destv(nex);
       v22=origv(nex);

--- a/MultiSource/Benchmarks/Olden/voronoi/output.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/output.c
@@ -1,22 +1,23 @@
 /* For copyright information, see olden_v1.0/COPYRIGHT */
 
 #include "defines.h"
-#include <stdio.h>
+#include <stdio_checked.h>
 
-extern struct VEC2 V2_sum();
-extern struct VEC2 V2_sub();
-extern struct VEC2 V2_times();
-extern double V2_cprod();
-extern struct VEC2 V2_cross();
-extern double V2_dot();
-extern double V2_magn();
+#pragma BOUNDS_CHECKED ON
+
+extern struct VEC2 V2_sum(struct VEC2 u, struct VEC2 v);
+extern struct VEC2 V2_sub(struct VEC2 u, struct VEC2 v);
+extern struct VEC2 V2_times(double c, struct VEC2 v);
+extern double V2_cprod(struct VEC2 u,struct VEC2 v);
+extern struct VEC2 V2_cross(struct VEC2 v);
+extern double V2_dot(struct VEC2 u, struct VEC2 v);
+extern double V2_magn(struct VEC2 u);
 
 /****************************************************************/
 /*	Voronoi Output Routines */
 /****************************************************************/
 
-void plot_dedge(p1, p2)
-VERTEX_PTR p1, p2;
+void plot_dedge(VERTEX_PTR p1, VERTEX_PTR p2)
 {
   double x1,x2,y1,y2;
 
@@ -25,12 +26,12 @@ VERTEX_PTR p1, p2;
   x2=X(p2);
   y2=Y(p2);
   /* plots a Delaunay-triangulation edge on your favorite device. */
+  _Unchecked {
   printf("Dedge %g %g %g %g \n",(float) x1, (float) y1,
-	 (float) x2, (float) y2);
+	 (float) x2, (float) y2); }
 }
 
-void plot_vedge(p1, p2)
-     struct VEC2 p1, p2;
+void plot_vedge(struct VEC2 p1, struct VEC2 p2)
 {
   /* plots a Voronoi-diagram edge on your favorite device. */
 
@@ -56,7 +57,7 @@ void plot_vedge(p1, p2)
   if (isnan(p2y))
     p2y = copysign(p2y, 1.0);
 
-  printf("Vedge %g %g %g %g \n", p1x, p1y, p2x, p2y);
+  _Unchecked { printf("Vedge %g %g %g %g \n", p1x, p1y, p2x, p2y); }
 }
 
 struct VEC2 circle_center(struct VEC2 a, struct VEC2 b, struct VEC2 c)
@@ -85,11 +86,11 @@ struct VEC2 circle_center(struct VEC2 a, struct VEC2 b, struct VEC2 c)
   }
 }
 
-int *earray;
+_Array_ptr<int> earray;
 
-void output_voronoi_diagram(QUAD_EDGE edge, int nv, struct EDGE_STACK *my_stack)
+void output_voronoi_diagram(QUAD_EDGE edge : count(4), int nv, _Ptr<struct EDGE_STACK> my_stack)
 {
-  QUAD_EDGE nex, prev, snex, sprev;
+  QUAD_EDGE nex : count(4) = NULL, prev : count(4) = NULL, snex : count(4) = NULL, sprev : count(4) = NULL;
   struct VEC2 cvxvec, center;
   double ln;
   
@@ -102,7 +103,7 @@ void output_voronoi_diagram(QUAD_EDGE edge, int nv, struct EDGE_STACK *my_stack)
     /*  Plot VD edges with one endpoint at infinity. */
     do {
       struct VEC2 v21,v22,v23;
-      QUAD_EDGE tmp;
+      QUAD_EDGE tmp : count(4) = NULL;
 
       v21=destv(nex);
       v22=origv(nex);
@@ -128,9 +129,9 @@ void output_voronoi_diagram(QUAD_EDGE edge, int nv, struct EDGE_STACK *my_stack)
   
   my_stack->ptr = 0;
   push_ring(my_stack, edge);
-  printf("mystack_ptr = %d\n",my_stack->ptr);
+  _Unchecked { printf("mystack_ptr = %d\n",my_stack->ptr); }
   while (my_stack->ptr != 0) {
-    VERTEX_PTR v1,v2,v3,v4;
+    VERTEX_PTR v1 = NULL, v2 = NULL, v3 = NULL, v4 = NULL;
     double d1,d2;
         
     edge = pop_edge(my_stack);

--- a/MultiSource/Benchmarks/Olden/voronoi/vector.c
+++ b/MultiSource/Benchmarks/Olden/voronoi/vector.c
@@ -2,6 +2,8 @@
 
 #include "defines.h"
 
+#pragma BOUNDS_CHECKED ON
+
 /****************************************************************
 //	Vector Routines.
 //	From CMU vision library.  


### PR DESCRIPTION
This is not yet complete, but I thought I'd push the branch anyway.

In particular, the bounds inference code can't cope with these macros. I'm not entirely sure why. 

```
#define sym(a) ((QUAD_EDGE) (((uptrint) (a)) ^ 2*SIZE))
#define rot(a) ((QUAD_EDGE) ( (((uptrint) (a) + 1*SIZE) & ANDF) | ((uptrint) (a) & ~ANDF) ))
#define rotinv(a) ((QUAD_EDGE) ( (((uptrint) (a) + 3*SIZE) & ANDF) | ((uptrint) (a) & ~ANDF) ))
#define base(a) ((QUAD_EDGE) ((uptrint a) & ~ANDF))
```