### PR TITLE
Benchmark Conversion of Ptrdist/ft

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.c
@@ -37,11 +37,12 @@
  */
 
 #include <assert.h>
-// CHECKED
 #include <stdio_checked.h>
 #include <stdlib_checked.h>
 #include "Fheap.h"
 #include "Fstruct.h"
+
+#pragma BOUNDS_CHECKED ON
 
 #ifdef DO_INLINE
 #define INLINE inline
@@ -59,7 +60,7 @@ void  RemoveChild(_Ptr<HeapP> );
 void  FixRank(_Ptr<HeapP> , int);
 
 INLINE void
-InitFHeap()
+InitFHeap(void)
 {
   int j;
 
@@ -143,7 +144,7 @@ DeleteMin(_Ptr<HeapP>  h)
 
   if(h1 == NULL)
   {
-    free((void*)h);
+    free(h);
     return(NULL);
   }
 
@@ -265,7 +266,7 @@ DeleteMin(_Ptr<HeapP>  h)
     }
   }
 
-  free((void*)h);
+  free(h);
 
   return(min);
 }
@@ -387,7 +388,7 @@ Delete(_Ptr<HeapP>  h, _Ptr<HeapP>  i)
     while(h1 != CHILD(i));
   }
 
-  free((void*)i);
+  free(i);
   return(h);
 }
 
@@ -498,11 +499,11 @@ NewHeap(_Ptr<Item>  i)
 {
   _Ptr<HeapP>  h = 0;
 
-  h = (HeapP *)calloc(1, sizeof(HeapP));
+  h = calloc(1, sizeof(HeapP));
 
   if(h == NULL)
   {
-    fprintf(stderr, "Oops, could not malloc\n");
+    _Unchecked { fprintf(stderr, "Oops, could not malloc\n"); }
     exit(1);
   }
   ITEM(h) = i;

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fheap.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fheap.h
@@ -51,6 +51,8 @@
  */
 #include "item.h"
 
+#pragma BOUNDS_CHECKED ON
+
 typedef struct _Heap
 {
   _Ptr<Item>      item;
@@ -78,7 +80,7 @@ typedef struct _Heap
  * Return values:
  *   none
  */
-void  InitFHeap();
+void  InitFHeap(void);
 
 /*
  * Create a heap structure.
@@ -217,5 +219,7 @@ _Ptr<HeapP>  Find(_Ptr<HeapP>  h, _Ptr<Item>  item);
  *   an pointer to the item
  */
 _Ptr<Item>  ItemOf(_Ptr<HeapP>  h);
+
+#pragma BOUNDS_CHECKED OFF
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.c
@@ -32,6 +32,8 @@
 #include "Fheap.h"
 #include "Fstruct.h"
 
+#pragma BOUNDS_CHECKED ON
+
 int
 SanityCheck1(_Ptr<HeapP>  h, _Ptr<Item>  i)
 {
@@ -149,22 +151,23 @@ PrettyPrint(_Ptr<HeapP>  h)
 
   if(h == NULL_HEAP)
   {
-    printf(" nil ");
+    _Unchecked { printf(" nil "); }
     return;
   }
 
-  printf("(");
+  _Unchecked { printf("("); }
 
   h1 = h;
   do
   {
     //PrintItem(ITEM(h1));
-    printf("[%u] ", RANK(h1));
+    _Unchecked { printf("[%u] ", RANK(h1)); }
     PrettyPrint(CHILD(h1));
     h1 = FORWARD(h1);
   }
   while(h1 != h);
 
-  printf(")");
+  _Unchecked { printf(")"); }
 }
 
+#pragma BOUNDS_CHECKED OFF

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fsanity.h
@@ -31,6 +31,8 @@
 #ifndef _fsanity_h
 #define _fsanity_h
 
+#pragma BOUNDS_CHECKED ON
+
 /*
  * Check the entry ordering in the structure.
  *
@@ -97,5 +99,7 @@ int  SanityCheck3(_Ptr<Heap> h, int rank);
  *   none
  */
 void PrettyPrint(_Ptr<Heap> h);
+
+#pragma BOUNDS_CHECKED OFF
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/Fstruct.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/Fstruct.h
@@ -39,6 +39,8 @@
 #ifndef _fstruct_h
 #define _fstruct_h
 
+#pragma BOUNDS_CHECKED ON
+
 #define ITEM(P)		((*(P)).item)
 #define PARENT(P)	((*(P)).parent)
 #define CHILD(P)	((*(P)).child)
@@ -54,5 +56,7 @@
 #define TRUE		1
 #define FALSE		0
 #define MAX_RANK	10000
+
+#pragma BOUNDS_CHECKED OFF
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/ft.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/ft.c
@@ -44,6 +44,8 @@
 #include "Fheap.h"
 #include "graph.h"
 
+#pragma BOUNDS_CHECKED ON
+
 #define MINUS_INFINITY		INT_MIN
 #define PLUS_INFINITY		INT_MAX
 
@@ -65,7 +67,7 @@ _Ptr<Vertices>  MST(_Ptr<Vertices>  graph);
  */
 int debug = 1;
 
-int
+_Unchecked int
 main(int argc, _Array_ptr<const char*> argv : count(argc) )
 {
   int            nVertex;
@@ -89,14 +91,14 @@ main(int argc, _Array_ptr<const char*> argv : count(argc) )
   }
 
   if(debug)
-  {
+  _Unchecked {
     printf("Generating a connected graph ... ");
   }
 
   graph = GenGraph(nVertex, nEdge);
 
   if(debug)
-  {
+  _Unchecked {
     printf("done\nFinding the mininmum spanning tree ... ");
   }
 
@@ -104,15 +106,15 @@ main(int argc, _Array_ptr<const char*> argv : count(argc) )
 
   if(debug)
   {
-    printf("done\nThe graph:\n");
+    _Unchecked { printf("done\nThe graph:\n"); }
     PrintGraph(graph);
-    printf("The minimum spanning tree:\n");
+    _Unchecked { printf("The minimum spanning tree:\n"); }
     PrintMST(graph);
   }
 
   if(debug)
   {
-    printf("Time spent in finding the mininum spanning tree:\n");
+    _Unchecked { printf("Time spent in finding the mininum spanning tree:\n"); }
   }
 #ifdef PLUS_STATS
   PrintDerefStats(stderr);
@@ -142,7 +144,7 @@ MST(_Ptr<Vertices>  graph)
   vertex = graph;
   KEY(vertex) = 0;
   heap = MakeHeap();
-  (void)Insert(&heap, (Item *)vertex);
+  (void)Insert(&heap, vertex);
 
   vertex = NEXT_VERTEX(vertex);
   while(vertex != graph)
@@ -185,7 +187,7 @@ PrintMST(_Ptr<Vertices>  graph)
 
   while(vertex != graph)
   {
-    printf("vertex %d to %d\n", ID(vertex), ID(SOURCE(CHOSEN_EDGE(vertex))));
+    _Unchecked { printf("vertex %d to %d\n", ID(vertex), ID(SOURCE(CHOSEN_EDGE(vertex)))); }
     vertex = NEXT_VERTEX(vertex);
   }
 

--- a/MultiSource/Benchmarks/Ptrdist/ft/ft.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/ft.c
@@ -69,7 +69,7 @@ int debug = 1;
 
 _Unchecked int
 main(int argc, _Array_ptr<const char*> argv : count(argc) )
-{
+_Checked {
   int            nVertex;
   int            nEdge;
   _Ptr<Vertices>   graph = 0;
@@ -78,7 +78,7 @@ main(int argc, _Array_ptr<const char*> argv : count(argc) )
   nEdge = DEFAULT_N_EDGE;
 
   if(argc > 1)
-  {
+  _Unchecked {
     nVertex = atoi(argv[1]);
     if(argc > 2)
     {

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.c
@@ -33,6 +33,8 @@
 #include <stdlib_checked.h>
 #include "graph.h"
 
+#pragma BOUNDS_CHECKED ON
+
 #define TRUE 1
 #define FALSE 0
 
@@ -228,7 +230,7 @@ NewVertex(void)
 
   if(vertex == NULL)
   {
-    fprintf(stderr, "Could not malloc\n");
+    _Unchecked { fprintf(stderr, "Could not malloc\n"); }
     exit(1);
   }
 
@@ -248,7 +250,7 @@ NewEdge(void)
 
   if(edge == NULL)
   {
-    fprintf(stderr, "Could not malloc\n");
+    _Unchecked { fprintf(stderr, "Could not malloc\n"); }
     exit(1);
   }
 
@@ -269,9 +271,9 @@ PrintGraph(_Ptr<Vertices>  graph)
   vertex = graph;
   do
   {
-    printf("Vertex %d is connected to:", ID(vertex));
+    _Unchecked { printf("Vertex %d is connected to:", ID(vertex)); }
     PrintNeighbors(vertex);
-    printf("\n");
+    _Unchecked { printf("\n"); }
     vertex = NEXT_VERTEX(vertex);
   }
   while(vertex != graph);
@@ -285,7 +287,7 @@ PrintNeighbors(_Ptr<Vertices>  vertex)
   edge = EDGES(vertex);
   while(edge != NULL)
   {
-    printf(" %d(%d)[%d]", ID(VERTEX(edge)), WEIGHT(edge), ID(SOURCE(edge)));
+    _Unchecked { printf(" %d(%d)[%d]", ID(VERTEX(edge)), WEIGHT(edge), ID(SOURCE(edge))); }
     edge = NEXT_EDGE(edge);
   }
 }

--- a/MultiSource/Benchmarks/Ptrdist/ft/graph.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/graph.h
@@ -31,6 +31,8 @@
 #ifndef _graph_h
 #define _graph_h
 
+#pragma BOUNDS_CHECKED ON
+
 struct _Vertices;
 
 typedef struct _Edges
@@ -74,5 +76,7 @@ typedef struct _Vertices
 
 _Ptr<Vertices>  GenGraph(int nVertex, int nEdge);
 void      PrintGraph(_Ptr<Vertices>  graph);
+
+#pragma BOUNDS_CHECKED OFF
 
 #endif

--- a/MultiSource/Benchmarks/Ptrdist/ft/item.c
+++ b/MultiSource/Benchmarks/Ptrdist/ft/item.c
@@ -34,6 +34,8 @@
 
 #include "item.h"
 
+#pragma BOUNDS_CHECKED ON
+
 int LessThan(_Ptr<Item>  item1, _Ptr<Item>  item2)
 {
   return(KEY(item1) < KEY(item2));

--- a/MultiSource/Benchmarks/Ptrdist/ft/item.h
+++ b/MultiSource/Benchmarks/Ptrdist/ft/item.h
@@ -33,6 +33,8 @@
 
 #include "graph.h"
 
+#pragma BOUNDS_CHECKED ON
+
 typedef Vertices Item;
 
 #define NULL_ITEM	NULL_VERTEX
@@ -40,5 +42,7 @@ typedef Vertices Item;
 int LessThan(_Ptr<Item> , _Ptr<Item> );
 int Equal(_Ptr<Item> , _Ptr<Item> );
 _Ptr<Item>  Subtract(_Ptr<Item> , int);
+
+#pragma BOUNDS_CHECKED OFF
 
 #endif


### PR DESCRIPTION
This fully converts Ptrdist/ft.

The execution error alluded to in #32 is fine to ignore - it's to do with `#define`d constants and the large input size. Given we're back to using the regular input size for benchmarking, I'm not worried right now about it. 

I should at some point add in a dynamic_check.