### PR TITLE
Fix for unchecked isalpha(int) bug in anagram.c

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -259,6 +259,8 @@ _Unchecked void Fatal(char *pchMsg, unsigned u) {
 
 int isalpha_checked(int ch) _Unchecked { return isalpha(ch); }
 #define isalpha(ch) isalpha_checked(ch)
+int tolower_checked(int ch) _Unchecked { return tolower(ch); }
+#define tolower(ch) tolower_checked(ch)
 
 /* ReadDict -- read the dictionary file into memory and preprocess it
  *

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -257,6 +257,9 @@ _Unchecked void Fatal(char *pchMsg, unsigned u) {
     exit(1);
 }
 
+int isalpha_checked(int ch) _Unchecked { return isalpha(ch); }
+#define isalpha(ch) isalpha_checked(ch)
+
 /* ReadDict -- read the dictionary file into memory and preprocess it
  *
  * A word of length cch in the dictionary is encoded as follows:

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -257,12 +257,8 @@ _Unchecked void Fatal(char *pchMsg, unsigned u) {
     exit(1);
 }
 
-#ifdef isalpha
-# undef isalpha
-#endif
-#ifdef tolower
-# undef tolower
-#endif
+#undef isalpha
+#undef tolower
 
 /* ReadDict -- read the dictionary file into memory and preprocess it
  *

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -257,10 +257,12 @@ _Unchecked void Fatal(char *pchMsg, unsigned u) {
     exit(1);
 }
 
-int isalpha_checked(int ch) _Unchecked { return isalpha(ch); }
-#define isalpha(ch) isalpha_checked(ch)
-int tolower_checked(int ch) _Unchecked { return tolower(ch); }
-#define tolower(ch) tolower_checked(ch)
+#ifdef isalpha
+# undef isalpha
+#endif
+#ifdef tolower
+# undef tolower
+#endif
 
 /* ReadDict -- read the dictionary file into memory and preprocess it
  *


### PR DESCRIPTION
Rather than introducing unchecked blocks, I thought it easier just to make 1-line unchecked wrappers, and then use `#define`s to make sure all calls to `isalpha` or `toletter` used the wrappers.

This keeps diffs small, and allows us to remove the wrappers later when we extend the specification to deal with bounds on inner checked array pointers.

Fixes #57