### PR TITLE
Change last K&R function in em3d

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/em3d.c
+++ b/MultiSource/Benchmarks/Olden/em3d/em3d.c
@@ -3,8 +3,7 @@
 #include "em3d.h"
 #pragma BOUNDS_CHECKED ON
 int nonlocals=0;
-void compute_nodes(nodelist)
-register ptr<node_t> nodelist;
+void compute_nodes(register ptr<node_t> nodelist)
 {
   register int i;
   register ptr<node_t> localnode = NULL;


### PR DESCRIPTION
We restrict the usage of K&R functions in lots of places in Checked C, and this function we missed during the prior conversion, when we should have caught it.