### PR TITLE
Hand Optimise Ptrdist/Anagram

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -516,7 +516,7 @@ Stat(unsigned long ulHighCount; unsigned long ulLowCount;)
 
 #define OneStep(i) \
     if ((aqNext[i] = pqMask[i] - pw->aqMask[i]) & aqMainSign[i]) { \
-        ppwStartTmp++; \
+        ppwStart++; \
         continue; \
     }
 
@@ -546,14 +546,12 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
     _Unchecked {Debug(printf("Pivoting on %c\n", i2ch(achByFrequency[iLetter]));)}
 
-    PPWord ppwStartTmp : bounds(ppwStartTmp, ppwEnd) = ppwStart;
-
     // Manually Hoisted Check, (including path condition) from first iteration of the loop.
-    _Dynamic_check(ppwStartTmp != NULL);
-    _Dynamic_check(ppwStartTmp < ppwEnd && ppwEnd <= (apwCand+MAXCAND));
+    _Dynamic_check(ppwStart != NULL);
+    _Dynamic_check(ppwStart < ppwEnd && ppwEnd <= (apwCand+MAXCAND));
 
-    while (ppwStartTmp < ppwEnd) {          /* Half of the program execution */
-        pw = *ppwStartTmp;                  /* time is spent in these three */
+    while (ppwStart < ppwEnd) {          /* Half of the program execution */
+        pw = *ppwStart;                  /* time is spent in these three */
 
         // This invariant is preserved in the code, but cannot be explained
         // to the compiler any other way at the moment.
@@ -583,7 +581,7 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
         /* If the pivot letter isn't present, defer this word until later */
         if ((pw->aqMask[iq] & qMask) == 0) {
-            *ppwStartTmp = *(ppwEnd - 1);
+            *ppwStart = *(ppwEnd - 1);
             --ppwEnd;
             *ppwEnd = pw;
             continue;
@@ -599,11 +597,11 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 	    ppwEnd = &apwCand[0];
 	    ppwEnd += cpwCand;
             FindAnagram(&aqNext[0],
-			ppwStartTmp, iLetter);
+			ppwStart, iLetter);
         } else DumpWords();             /* found one */
         cchPhraseLength += pw->cchLength;
         --cpwLast;
-        ppwStartTmp++;
+        ppwStart++;
         continue;
     }
 

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -516,7 +516,7 @@ Stat(unsigned long ulHighCount; unsigned long ulLowCount;)
 
 #define OneStep(i) \
     if ((aqNext[i] = pqMask[i] - pw->aqMask[i]) & aqMainSign[i]) { \
-        ppwStart++; \
+        ppwStartTmp++; \
         continue; \
     }
 
@@ -546,10 +546,12 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
     _Unchecked {Debug(printf("Pivoting on %c\n", i2ch(achByFrequency[iLetter]));)}
 
+    PPWord ppwStartTmp : bounds(ppwStartTmp, ppwEnd) = ppwStart;
+
     _Dynamic_check(ppwStart != NULL); // Manually Hoisted Check
 
-    while (ppwStart < ppwEnd) {          /* Half of the program execution */
-        pw = *ppwStart;                  /* time is spent in these three */
+    while (ppwStartTmp < ppwEnd) {          /* Half of the program execution */
+        pw = *ppwStartTmp;                  /* time is spent in these three */
 
         __builtin_assume(pw != NULL); // This has the effect of saying *ppwStart is non-null.
 
@@ -577,7 +579,8 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
         /* If the pivot letter isn't present, defer this word until later */
         if ((pw->aqMask[iq] & qMask) == 0) {
-            *ppwStart = *--ppwEnd;
+            *ppwStartTmp = *(ppwEnd - 1);
+            --ppwEnd;
             *ppwEnd = pw;
             continue;
         }
@@ -592,11 +595,11 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 	    ppwEnd = &apwCand[0];
 	    ppwEnd += cpwCand;
             FindAnagram(&aqNext[0],
-			ppwStart, iLetter);
+			ppwStartTmp, iLetter);
         } else DumpWords();             /* found one */
         cchPhraseLength += pw->cchLength;
         --cpwLast;
-        ppwStart++;
+        ppwStartTmp++;
         continue;
     }
 

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -553,10 +553,6 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
     while (ppwStart < ppwEnd) {          /* Half of the program execution */
         pw = *ppwStart;                  /* time is spent in these three */
 
-        // This invariant is preserved in the code, but cannot be explained
-        // to the compiler any other way at the moment.
-        __builtin_assume(pw != NULL);
-
         Stat(if (++ulLowCount == 0) ++ulHighCount;)
 
 #if MAX_QUADS > 0

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -209,7 +209,7 @@ typedef struct {
     unsigned cchLength;                 /* letters in the word */
 } Word;
 typedef _Ptr<Word> PWord;
-typedef _Array_ptr<_Ptr<Word>> PPWord;
+typedef _Array_ptr<PWord> PPWord;
 
 PWord apwCand _Checked [MAXCAND];    /* candidates we've found so far */
 unsigned cpwCand;                       /* how many of them? */
@@ -521,13 +521,13 @@ Stat(unsigned long ulHighCount; unsigned long ulLowCount;)
     }
 
 void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
-        PPWord ppwStart : bounds(apwCand, apwCand+MAXCAND), int iLetter)
+        PPWord ppwStart : bounds(ppwStart, apwCand+cpwCand), int iLetter)
 {
     Quad aqNext _Checked [MAX_QUADS];
     register PWord pw = 0;
     Quad qMask;
     unsigned iq;
-    PPWord ppwEnd : bounds(apwCand, apwCand+MAXCAND) = &apwCand[0];
+    PPWord ppwEnd : bounds(ppwStart, apwCand+cpwCand) = &apwCand[0];
     ppwEnd += cpwCand;
 
     ;
@@ -546,8 +546,12 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
     _Unchecked {Debug(printf("Pivoting on %c\n", i2ch(achByFrequency[iLetter]));)}
 
+    _Dynamic_check(ppwStart != NULL); // Manually Hoisted Check
+
     while (ppwStart < ppwEnd) {          /* Half of the program execution */
         pw = *ppwStart;                  /* time is spent in these three */
+
+        __builtin_assume(pw != NULL); // This has the effect of saying *ppwStart is non-null.
 
         Stat(if (++ulLowCount == 0) ++ulHighCount;)
 

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -521,7 +521,7 @@ Stat(unsigned long ulHighCount; unsigned long ulLowCount;)
     }
 
 void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
-        PPWord ppwStart : bounds(ppwStart, apwCand+cpwCand), int iLetter)
+        PPWord ppwStart : bounds(ppwStart, apwCand+MAXCAND), int iLetter)
 {
     Quad aqNext _Checked [MAX_QUADS];
     register PWord pw = 0;
@@ -548,8 +548,9 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
     PPWord ppwStartTmp : bounds(ppwStartTmp, ppwEnd) = ppwStart;
 
-    // Manually Hoisted Check, including path condition for first iteration of the loop.
-    _Dynamic_check(ppwStartTmp < ppwEnd && ppwStartTmp != NULL);
+    // Manually Hoisted Check, (including path condition) from first iteration of the loop.
+    _Dynamic_check(ppwStartTmp != NULL);
+    _Dynamic_check(ppwStartTmp < ppwEnd && ppwEnd <= (apwCand+MAXCAND));
 
     while (ppwStartTmp < ppwEnd) {          /* Half of the program execution */
         pw = *ppwStartTmp;                  /* time is spent in these three */

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -581,8 +581,7 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
         /* If the pivot letter isn't present, defer this word until later */
         if ((pw->aqMask[iq] & qMask) == 0) {
-            *ppwStart = *(ppwEnd - 1);
-            --ppwEnd;
+            *ppwStart = *--ppwEnd;
             *ppwEnd = pw;
             continue;
         }

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -548,12 +548,15 @@ void FindAnagram(_Array_ptr<Quad> pqMask : count(MAX_QUADS),
 
     PPWord ppwStartTmp : bounds(ppwStartTmp, ppwEnd) = ppwStart;
 
-    _Dynamic_check(ppwStart != NULL); // Manually Hoisted Check
+    // Manually Hoisted Check, including path condition for first iteration of the loop.
+    _Dynamic_check(ppwStartTmp < ppwEnd && ppwStartTmp != NULL);
 
     while (ppwStartTmp < ppwEnd) {          /* Half of the program execution */
         pw = *ppwStartTmp;                  /* time is spent in these three */
 
-        __builtin_assume(pw != NULL); // This has the effect of saying *ppwStart is non-null.
+        // This invariant is preserved in the code, but cannot be explained
+        // to the compiler any other way at the moment.
+        __builtin_assume(pw != NULL);
 
         Stat(if (++ulLowCount == 0) ++ulHighCount;)
 


### PR DESCRIPTION
I heard you don't like 40% slowdowns. How does 2.5% sound?

Changes:
- Dynamic non-null check manually hoisted to before loop
- ppwStart replaced with temporary that has more accurate bounds
- changes to ppwEnd properly sequenced with respect to access to ppwStart temporary
- using slightly hacky `__builtin_assume` to tell clang that a certain pointer is non-null. This is always the case, and if we had nullness annotations on our pointers this is the information that would be propagated with those annotations. 