### PR TITLE
Benchmark Conversion of Ptrdist/yacr2

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/yacr2/assign.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/assign.h
@@ -18,7 +18,7 @@
 #ifndef ASSIGN_H
 #define ASSIGN_H
 
-
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Defines.
@@ -37,6 +37,11 @@
  *
  */
 
+struct costMatrixRow {
+    _Array_ptr<long> row : count(len);
+    ulong len;
+};
+
 
 /*
  *
@@ -44,33 +49,36 @@
  *
  */
 
+extern ulong channelNets;
+extern ulong channelTracks;
+
 #ifdef ASSIGN_CODE
 
-long * *			costMatrix;
-ulong *			tracksNoHCV;
-ulong *			tracksNotPref;
-ulong *			tracksTopNotPref;
-ulong *			tracksBotNotPref;
+_Array_ptr<struct costMatrixRow>			costMatrix : count(channelNets + 1);
+_Array_ptr<ulong>			tracksNoHCV : count(channelTracks+2);
+_Array_ptr<ulong>			tracksNotPref : count(channelTracks+2);
+_Array_ptr<ulong>			tracksTopNotPref : count(channelTracks+2);
+_Array_ptr<ulong>			tracksBotNotPref : count(channelTracks+2);
 ulong				cardNotPref;
 ulong				cardTopNotPref;
 ulong				cardBotNotPref;
-ulong *			tracksAssign;
-ulong *			netsAssign;
-ulong *			netsAssignCopy;
+_Array_ptr<ulong>			tracksAssign : count(channelTracks+2);
+_Array_ptr<ulong>			netsAssign : count(channelNets + 1);
+_Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
 
 #else	/* ASSIGN_CODE */
 
-extern ulong * *		costMatrix;
-extern ulong *		tracksNoHCV;
-extern ulong *		tracksNotPref;
-extern ulong *		tracksTopNotPref;
-extern ulong *		tracksBotNotPref;
-extern ulong			cardNotPref;
-extern ulong			cardTopNotPref;
-extern ulong			cardBotNotPref;
-extern ulong *		tracksAssign;
-extern ulong *		netsAssign;
-extern ulong *		netsAssignCopy;
+extern _Array_ptr<struct costMatrixRow>			costMatrix : count(channelNets + 1); // 2dim, second dim is (channelTracks + 2)
+extern _Array_ptr<ulong>			tracksNoHCV : count(channelTracks+2);
+extern _Array_ptr<ulong>			tracksNotPref : count(channelTracks+2);
+extern _Array_ptr<ulong>			tracksTopNotPref : count(channelTracks+2);
+extern _Array_ptr<ulong>			tracksBotNotPref : count(channelTracks+2);
+extern ulong				cardNotPref;
+extern ulong				cardTopNotPref;
+extern ulong				cardBotNotPref;
+extern _Array_ptr<ulong>			tracksAssign : count(channelTracks+2);
+extern _Array_ptr<ulong>			netsAssign : count(channelNets + 1);
+extern _Array_ptr<ulong>			netsAssignCopy : count(channelNets + 1);
 
 #endif	/* ASSIGN_CODE */
 
@@ -102,28 +110,28 @@ void
 LeftNetsAssign(void);
 
 void
-Assign(nodeVCGType *,
-       ulong *,
+Assign(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+       _Array_ptr<ulong> : count(channelNets + 1),
        ulong);
 
 void
-Select(nodeVCGType *,
-       nodeHCGType *,
-       ulong *,
-       ulong *,
-       ulong *);
+Select(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+       _Array_ptr<nodeHCGType> : count(channelNets + 1),
+       _Array_ptr<ulong> : count(channelNets + 1),
+       _Ptr<ulong>,
+       _Array_ptr<ulong> : count(channelNets + 1));
 
 void
-BuildCostMatrix(nodeVCGType *,
-		nodeHCGType *,
-		ulong *,
-		ulong *);
+BuildCostMatrix(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+        _Array_ptr<nodeHCGType> : count(channelNets + 1),
+        _Array_ptr<ulong> : count(channelNets + 1),
+        _Array_ptr<ulong> : count(channelNets + 1));
 
 void
 IdealTrack(ulong,
 	   ulong,
 	   ulong,
-	   ulong *);
+	   _Ptr<ulong>);
 
 #else	/* ASSIGN_CODE */
 
@@ -146,30 +154,31 @@ extern void
 LeftNetsAssign(void);
 
 extern void
-Assign(nodeVCGType *,
-       ulong *,
+Assign(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+       _Array_ptr<ulong> : count(channelNets + 1),
        ulong);
 
 extern void
-Select(nodeVCGType *,
-       nodeHCGType *,
-       ulong *,
-       ulong *,
-       ulong *);
+Select(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+       _Array_ptr<nodeHCGType> : count(channelNets + 1),
+       _Array_ptr<ulong> : count(channelNets + 1),
+       _Ptr<ulong>,
+       _Array_ptr<ulong> : count(channelNets + 1));
 
 extern void
-BuildCostMatrix(nodeVCGType *,
-		nodeHCGType *,
-		ulong *,
-		ulong *);
+BuildCostMatrix(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+        _Array_ptr<nodeHCGType> : count(channelNets + 1),
+        _Array_ptr<ulong> : count(channelNets + 1),
+        _Array_ptr<ulong> : count(channelNets + 1));
 
 extern void
 IdealTrack(ulong,
 	   ulong,
 	   ulong,
-	   ulong *);
+	   _Ptr<ulong>);
 
 #endif	/* ASSIGN_CODE */
 
+#pragma BOUNDS_CHECKED OFF
 #endif	/* ASSIGN_H */
 

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/channel.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/channel.c
@@ -14,11 +14,12 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include "types.h"
 #include "channel.h"
 
+#pragma BOUNDS_CHECKED ON
 
 /*
  *
@@ -52,7 +53,7 @@ BuildChannel(void)
 void
 DimensionChannel(void)
 {
-    FILE	*channelFP;
+    _Ptr<FILE>	channelFP = NULL;
     ulong	line;
     ulong	dim;
     ulong	net;
@@ -64,8 +65,8 @@ DimensionChannel(void)
     /*
      * Open channel description file.
      */
-    channelFP = fopen(channelFile, "r");
-    if (channelFP == NULL) {
+    _Unchecked { channelFP = fopen(channelFile, "r"); }
+    if (channelFP == NULL) _Unchecked {
 	/*
 	 * Error in channel file description.
 	 */
@@ -88,7 +89,7 @@ DimensionChannel(void)
     do {
 	line++;
 	unsigned int c1, b1, t1;
-	stat = fscanf(channelFP, "%u%u%u", &c1, &b1, &t1);
+	_Unchecked { stat = fscanf(channelFP, "%u%u%u", &c1, &b1, &t1); }
 	col = c1; bot = b1; top = t1;
 	if (stat != EOF) {
 	    if (stat == 3) {
@@ -109,7 +110,7 @@ DimensionChannel(void)
 		    net = top;
 		}
 	    }
-	    else {
+	    else _Unchecked {
 		/*
 		 * Error in channel file description.
 		 */
@@ -123,8 +124,8 @@ DimensionChannel(void)
 
     /*
      * Close channel description file.
-     */
-    if (fclose(channelFP) == EOF) {
+	 */
+    if (fclose(channelFP) == EOF) _Unchecked {
 	/*
 	 * Error in channel file description.
 	 */
@@ -136,7 +137,7 @@ DimensionChannel(void)
     /*
      * Check channel dimension.
      */
-    if (dim == 0) {
+    if (dim == 0) _Unchecked {
 	/*
 	 * Error in channel file description.
 	 */
@@ -156,7 +157,7 @@ DimensionChannel(void)
 void
 DescribeChannel(void)
 {
-    FILE	*channelFP;
+    _Ptr<FILE> channelFP = NULL;
     ulong	line;
     ulong	col;
     ulong	bot;
@@ -166,12 +167,12 @@ DescribeChannel(void)
     /*
      * Top terminals of channel.
      */
-    TOP = (ulong *)malloc((channelColumns+1) * sizeof(ulong));
+    TOP = malloc((channelColumns+1) * sizeof(ulong));
 
     /*
      * Bottom terminals of channel.
      */
-    BOT = (ulong *)malloc((channelColumns+1) * sizeof(ulong));
+    BOT = malloc((channelColumns+1) * sizeof(ulong));
 
     /*
      * Initialize terminals of channel.
@@ -184,8 +185,8 @@ DescribeChannel(void)
     /*
      * Open channel description file.
      */
-    channelFP = fopen(channelFile, "r");
-    if (channelFP == NULL) {
+    _Unchecked { channelFP = fopen(channelFile, "r"); }
+    if (channelFP == NULL) _Unchecked {
 	/*
 	 * Error in channel file description.
 	 */
@@ -206,14 +207,14 @@ DescribeChannel(void)
     do {
 	line++;
 	unsigned int c1, b1, t1;
-	stat = fscanf(channelFP, "%u%u%u", &c1, &b1, &t1);
+	_Unchecked { stat = fscanf(channelFP, "%u%u%u", &c1, &b1, &t1); }
 	col = c1; bot = b1; top = t1;
 	if (stat != EOF) {
 	    if (stat == 3) {
 		/*
 		 * Build column.
 		 */
-		if (col > channelColumns) {
+		if (col > channelColumns) _Unchecked {
 		    /*
 		     * Error in channel file description.
 		     */
@@ -230,7 +231,7 @@ DescribeChannel(void)
 		    TOP[col] = top;
 		}
 	    }
-	    else {
+	    else _Unchecked {
 		/*
 		 * Error in channel file description.
 		 */
@@ -245,7 +246,7 @@ DescribeChannel(void)
     /*
      * Close channel description file.
      */
-    if (fclose(channelFP) == EOF) {
+    if (fclose(channelFP) == EOF) _Unchecked {
 	/*
 	 * Error in channel file description.
 	 */
@@ -267,10 +268,10 @@ DensityChannel(void)
     /*
      * Allocate track dimension structures.
      */
-    FIRST = (ulong *)malloc((channelNets+1) * sizeof(ulong));
-    LAST = (ulong *)malloc((channelNets+1) * sizeof(ulong));
-    DENSITY = (ulong *)malloc((channelColumns+1) * sizeof(ulong));
-    CROSSING = (ulong *)malloc((channelNets+1) * sizeof(ulong));
+    FIRST = malloc((channelNets+1) * sizeof(ulong));
+    LAST = malloc((channelNets+1) * sizeof(ulong));
+    DENSITY = malloc((channelColumns+1) * sizeof(ulong));
+    CROSSING = malloc((channelNets+1) * sizeof(ulong));
 
     /*
      * Initialize track dimension structures.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/channel.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/channel.h
@@ -18,7 +18,9 @@
 #ifndef CHANNEL_H
 #define CHANNEL_H
 
+char *		channelFile;
 
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Defines.
@@ -41,35 +43,34 @@
 
 #ifdef CHANNEL_CODE
 
-ulong *		TOP;
-ulong *		BOT;
-ulong *		FIRST;
-ulong *		LAST;
-ulong *		DENSITY;
-ulong *		CROSSING;
 ulong			channelNets;
 ulong			channelColumns;
+_Array_ptr<ulong>		TOP : count(channelColumns + 1);
+_Array_ptr<ulong>		BOT : count(channelColumns + 1);
+_Array_ptr<ulong>		FIRST : count(channelNets + 1);
+_Array_ptr<ulong>		LAST : count(channelNets + 1);
+_Array_ptr<ulong>		DENSITY : count(channelColumns + 1);
+_Array_ptr<ulong>		CROSSING : count(channelNets + 1);
 ulong			channelTracks;
 ulong			channelTracksCopy;
 ulong			channelDensity;
 ulong			channelDensityColumn;
-char *		channelFile;
+
 
 #else	/* CHANNEL_CODE */
 
-extern ulong *	TOP;
-extern ulong *	BOT;
-extern ulong *	FIRST;
-extern ulong *	LAST;
-extern ulong *	DENSITY;
-extern ulong *	CROSSING;
 extern ulong		channelNets;
 extern ulong		channelColumns;
+extern _Array_ptr<ulong>		TOP : count(channelColumns + 1);
+extern _Array_ptr<ulong>		BOT : count(channelColumns + 1);
+extern _Array_ptr<ulong>		FIRST : count(channelNets + 1);
+extern _Array_ptr<ulong>		LAST : count(channelNets + 1);
+extern _Array_ptr<ulong>		DENSITY : count(channelColumns + 1);
+extern _Array_ptr<ulong>		CROSSING : count(channelNets + 1);
 extern ulong		channelTracks;
 extern ulong		channelTracksCopy;
 extern ulong		channelDensity;
 extern ulong		channelDensityColumn;
-extern char *	channelFile;
 
 #endif	/* CHANNEL_CODE */
 
@@ -110,4 +111,5 @@ DensityChannel(void);
 
 #endif	/* CHANNEL_CODE */
 
+#pragma BOUNDS_CHECKED OFF
 #endif	/* CHANNEL_H */

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/hcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/hcg.c
@@ -14,14 +14,14 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include <assert.h>
 #include "types.h"
 #include "hcg.h"
 #include "channel.h"
 
-
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Code.
@@ -31,8 +31,8 @@
 void
 AllocHCG(void)
 {
-    HCG = (nodeHCGType *)malloc((channelNets + 1) * sizeof(nodeHCGType));
-    storageRootHCG = (ulong *)malloc((channelNets + 1) * (channelNets + 1) * sizeof(ulong));
+    HCG = malloc((channelNets + 1) * sizeof(nodeHCGType));
+    storageRootHCG = malloc((channelNets + 1) * (channelNets + 1) * sizeof(ulong));
     storageHCG = storageRootHCG;
     storageLimitHCG = (channelNets + 1) * (channelNets + 1);
 }
@@ -68,6 +68,7 @@ BuildHCG(void)
 	first = FIRST[net];
 	last = LAST[net];
 	constraint = 0;
+	HCG[net].nets = constraint;
 	HCG[net].netsHook = storageHCG;
 	for (which = 1; which <= channelNets; which++) {
 	    if (((FIRST[which] < first) && (LAST[which] < first)) || ((FIRST[which] > last) && (LAST[which] > last))) {
@@ -95,6 +96,7 @@ BuildHCG(void)
 		 * Add constraint.
 		 */
 		assert(storageLimitHCG > 0);
+		HCG[net].nets = constraint;
 		HCG[net].netsHook[constraint] = which;
 		storageHCG++;
 		storageLimitHCG--;
@@ -106,7 +108,7 @@ BuildHCG(void)
 }
 
 void
-DFSClearHCG(nodeHCGType * HCG)
+DFSClearHCG(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1))
 {
     ulong	net;
 
@@ -116,12 +118,12 @@ DFSClearHCG(nodeHCGType * HCG)
 }
 
 void
-DumpHCG(nodeHCGType * HCG)
+DumpHCG(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1))
 {
     ulong	net;
     ulong	which;
 
-    for (net = 1; net <= channelNets; net++) {
+    for (net = 1; net <= channelNets; net++) _Unchecked {
 	printf("[%d]\n", net);
 	for (which = 0; which < HCG[net].nets; which++) {
 	    printf("%d ", HCG[net].netsHook[which]);
@@ -131,10 +133,10 @@ DumpHCG(nodeHCGType * HCG)
 }
 
 void
-NoHCV(nodeHCGType * HCG,
+NoHCV(_Array_ptr<nodeHCGType> HCG : count(channelNets + 1),
       ulong select,
-      ulong * netsAssign,
-      ulong * tracksNoHCV)
+      _Array_ptr<ulong> netsAssign : count(channelNets + 1),
+      _Array_ptr<ulong> tracksNoHCV : count(channelTracks + 2))
 {
     ulong	track;
     ulong	net;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/hcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/hcg.h
@@ -17,6 +17,7 @@
 #ifndef HCG_H
 #define HCG_H
 
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Defines.
@@ -31,7 +32,7 @@
  */
 
 typedef struct _nodeHCGType {
-    ulong *	netsHook;
+    _Array_ptr<ulong>	netsHook : count(nets + 1);
     ulong	nets;
     ulong	netsReached;
 } nodeHCGType;
@@ -43,18 +44,21 @@ typedef struct _nodeHCGType {
  *
  */
 
+extern ulong channelNets;
+extern ulong channelTracks;
+
 #ifdef HCG_CODE
 
-nodeHCGType *			HCG;
-ulong *				storageRootHCG;
-ulong *				storageHCG;
+_Array_ptr<nodeHCGType>			HCG : count(channelNets + 1);
+_Array_ptr<ulong>				storageRootHCG : count(channelNets + 1);
+_Array_ptr<ulong>				storageHCG : bounds(storageRootHCG, storageRootHCG + channelNets + 1);
 ulong					storageLimitHCG;
 
 #else	/* HCG_CODE */
 
-extern nodeHCGType *			HCG;
-extern ulong *			storageRootHCG;
-extern ulong *			storageHCG;
+extern _Array_ptr<nodeHCGType>			HCG : count(channelNets + 1);
+extern _Array_ptr<ulong>			storageRootHCG : count(channelNets + 1);
+extern _Array_ptr<ulong>			storageHCG : bounds(storageRootHCG, storageRootHCG + channelNets + 1);
 extern ulong				storageLimitHCG;
 
 #endif	/* HCG_CODE */
@@ -78,16 +82,16 @@ void
 BuildHCG(void);
 
 void
-DFSClearHCG(nodeHCGType *);
+DFSClearHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
 
 void
-DumpHCG(nodeHCGType *);
+DumpHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
 
 void
-NoHCV(nodeHCGType *,
+NoHCV(_Array_ptr<nodeHCGType> : count(channelNets + 1),
       ulong,
-      ulong *,
-      ulong *);
+      _Array_ptr<ulong> : count(channelNets + 1),
+      _Array_ptr<ulong> : count(channelTracks + 2));
 
 #else	/* HCG_CODE */
 
@@ -101,17 +105,18 @@ extern void
 BuildHCG(void);
 
 extern void
-DFSClearHCG(nodeHCGType *);
+DFSClearHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
 
 extern void
-DumpHCG(nodeHCGType *);
+DumpHCG(_Array_ptr<nodeHCGType> : count(channelNets + 1));
 
 extern void
-NoHCV(nodeHCGType *,
+NoHCV(_Array_ptr<nodeHCGType> : count(channelNets + 1),
       ulong,
-      ulong *,
-      ulong *);
+      _Array_ptr<ulong> : count(channelNets + 1),
+      _Array_ptr<ulong> : count(channelTracks + 2));
 
 #endif	/* HCG_CODE */
 
+#pragma BOUNDS_CHECKED OFF
 #endif	/* HCG_H */

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/main.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/main.c
@@ -15,8 +15,8 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include <assert.h>
 #include "option.h"
 #include "channel.h"
@@ -26,15 +26,16 @@
 #include "maze.h"
 
 
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Code.
  *
  */
 
-int
+_Unchecked int
 main(int argc,
-     char *argv[])
+     _Array_ptr<char*> argv : count(argc))
 {
     ulong      	done;
     ulong	fail;
@@ -74,17 +75,17 @@ for (TIMELOOP = 0; TIMELOOP < 20; ++TIMELOOP) {
 	do {
 	    done = TRUE;
 	    if ((netsLeft = DrawNets()) != 0) {
-		printf("Assignment could not route %d columns, trying maze1...\n",
-		       netsLeft);
+		_Unchecked { printf("Assignment could not route %d columns, trying maze1...\n",
+		       netsLeft); }
 		if ((netsLeft = Maze1()) != 0) {
-		    printf("Maze1 could not route %d columns, trying maze2...\n",
-			   netsLeft);
+		    _Unchecked { printf("Maze1 could not route %d columns, trying maze2...\n",
+			   netsLeft); }
 		    if ((netsLeft = Maze2()) != 0) {
-			printf("Maze2 could not route %d columns, trying maze3...\n",
-			       netsLeft);
+			_Unchecked { printf("Maze2 could not route %d columns, trying maze3...\n",
+			       netsLeft); }
 			if ((netsLeft = Maze3()) != 0) {
-			    printf("Maze3 could not route %d columns, adding a track...\n",
-				   netsLeft);
+			    _Unchecked { printf("Maze3 could not route %d columns, adding a track...\n",
+				   netsLeft); }
 			    /* PrintChannel(); */
 			    if (! fail) {
 				channelTracks++;
@@ -113,7 +114,7 @@ for (TIMELOOP = 0; TIMELOOP < 20; ++TIMELOOP) {
 	     */
 	    if ((! done) && fail) {
 #ifdef VERBOSE
-		printf("\n*** fail (insert track at %d) ***\n", fail);
+		_Unchecked { printf("\n*** fail (insert track at %d) ***\n", fail); }
 #endif
 		for (insert = 1; insert <= channelNets; insert++) {
 		    if (netsAssign[insert] >= fail) {
@@ -134,7 +135,7 @@ for (TIMELOOP = 0; TIMELOOP < 20; ++TIMELOOP) {
 	}
     } while (! done);
 
-    printf("\n");
+    _Unchecked { printf("\n"); }
     PrintChannel();
 #ifdef PLUS_STATS
     PrintDerefStats(stderr);

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/maze.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/maze.h
@@ -2,6 +2,7 @@
 #ifndef MAZE_H
 #define MAZE_H
 
+#pragma BOUNDS_CHECKED ON
 void InitAllocMaps(void);
 void FreeAllocMaps(void);
 void PrintChannel(void);
@@ -10,4 +11,5 @@ int Maze1(void);
 int Maze2(void);
 int Maze3(void);
 
+#pragma BOUNDS_CHECKED OFF
 #endif /* MAZE_H */

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/option.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/option.c
@@ -5,7 +5,7 @@
  *
  */
 
-#include <string.h>
+#include <string_checked.h>
 
 #define OPTION_CODE
 
@@ -16,10 +16,11 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include "channel.h"
 
+#pragma BOUNDS_CHECKED ON
 
 /*
  *
@@ -27,9 +28,9 @@
  *
  */
 
-void
+_Unchecked void
 Option(int argc,
-       char *argv[])
+       _Array_ptr<char*> argv : count(argc))
 {
     /*
      * Check arguments.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/option.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/option.h
@@ -15,6 +15,7 @@
 #ifndef OPTION_H
 #define OPTION_H
 
+#pragma BOUNDS_CHECKED ON
 
 /*
  *
@@ -51,16 +52,17 @@
 
 #ifdef OPTION_CODE
 
-void
-Option(int,
-       char (*[]));
+_Unchecked void
+Option(int argc,
+       _Array_ptr<char*> : count(argc));
 
 #else	/* OPTION_CODE */
 
-extern void
-Option(int,
-       char (*[]));
+_Unchecked extern void
+Option(int argc,
+       _Array_ptr<char*> : count(argc));
 
 #endif	/* OPTION_CODE */
 
+#pragma BOUNDS_CHECKED OFF
 #endif	/* OPTION_H */

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -15,14 +15,15 @@
  *
  */
 
-#include <stdio.h>
-#include <stdlib.h>
+#include <stdio_checked.h>
+#include <stdlib_checked.h>
 #include <assert.h>
 #include "types.h"
 #include "vcg.h"
 #include "assign.h"
 #include "channel.h"
 
+#pragma BOUNDS_CHECKED ON
 
 /*
  *
@@ -33,13 +34,13 @@
 void
 AllocVCG(void)
 {
-    VCG = (nodeVCGType *)malloc((channelNets + 1) * sizeof(nodeVCGType));
-    storageRootVCG = (constraintVCGType *)malloc((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType));
+    VCG = malloc((channelNets + 1) * sizeof(nodeVCGType));
+    storageRootVCG = malloc((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType));
     storageVCG = storageRootVCG;
     storageLimitVCG = (channelNets + 1) * (channelNets + 1);
-    SCC = (ulong *)malloc((channelNets + 1) * sizeof(ulong));
-    perSCC = (ulong *)malloc((channelNets + 1) * sizeof(ulong));
-    removeVCG = (constraintVCGType * *)malloc((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
+    SCC = malloc((channelNets + 1) * sizeof(ulong));
+    perSCC = malloc((channelNets + 1) * sizeof(ulong));
+    removeVCG = malloc((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
 }
 
 void
@@ -93,7 +94,8 @@ BuildVCG(void)
 		 * Add constraint.
 		 */
 		if (add) {
-		    assert(storageLimitVCG > 0);
+			assert(storageLimitVCG > 0);
+			VCG[net].netsAbove = constraint;
 		    VCG[net].netsAboveHook[constraint].top = TOP[col];
 		    VCG[net].netsAboveHook[constraint].bot = BOT[col];
 		    VCG[net].netsAboveHook[constraint].col = col;
@@ -128,7 +130,8 @@ BuildVCG(void)
 		 * Add constraint.
 		 */
 		if (add) {
-		    assert(storageLimitVCG > 0);
+			assert(storageLimitVCG > 0);
+			VCG[net].netsBelow = constraint;
 		    VCG[net].netsBelowHook[constraint].top = TOP[col];
 		    VCG[net].netsBelowHook[constraint].bot = BOT[col];
 		    VCG[net].netsBelowHook[constraint].col = col;
@@ -144,7 +147,7 @@ BuildVCG(void)
 }
 
 void
-DFSClearVCG(nodeVCGType * VCG)
+DFSClearVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
 {
     ulong	net;
 
@@ -157,35 +160,35 @@ DFSClearVCG(nodeVCGType * VCG)
 }
 
 void
-DumpVCG(nodeVCGType * VCG)
+DumpVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1))
 {
     ulong	net;
     ulong	which;
 
     for (net = 1; net <= channelNets; net++) {
-	printf("[%d]\n", net);
-	printf("above: ");
+	_Unchecked { printf("[%d]\n", net); }
+	_Unchecked { printf("above: "); }
 	for (which = 0; which < VCG[net].netsAbove; which++) {
 	    if (! VCG[net].netsAboveHook[which].removed) {
 		assert(VCG[net].netsAboveHook[which].top == net);
-		printf("%d ", VCG[net].netsAboveHook[which].bot);
+		_Unchecked { printf("%d ", VCG[net].netsAboveHook[which].bot); }
 	    }
 	}
 
-	printf("\n");
-	printf("below: ");
+	_Unchecked { printf("\n"); }
+    _Unchecked { printf("below: "); }
 	for (which = 0; which < VCG[net].netsBelow; which++) {
 	    if (! VCG[net].netsBelowHook[which].removed) {
 		assert(VCG[net].netsBelowHook[which].bot == net);
-		printf("%d ", VCG[net].netsBelowHook[which].top);
+		_Unchecked { printf("%d ", VCG[net].netsBelowHook[which].top); }
 	    }
 	}
-	printf("\n\n");
+	_Unchecked { printf("\n\n"); }
     }	
 }
 
 void
-DFSAboveVCG(nodeVCGType * VCG,
+DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	    ulong net)
 {
     ulong	s;
@@ -204,7 +207,7 @@ DFSAboveVCG(nodeVCGType * VCG,
 }
 
 void
-DFSBelowVCG(nodeVCGType * VCG,
+DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	    ulong net)
 {
     ulong	s;
@@ -223,9 +226,9 @@ DFSBelowVCG(nodeVCGType * VCG,
 }
 
 void
-SCCofVCG(nodeVCGType * VCG,
-	 ulong * SCC,
-	 ulong * perSCC)
+SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
+	     _Array_ptr<ulong> SCC : count(channelNets + 1),
+		 _Array_ptr<ulong> perSCC : count(totalSCC + 1))
 {
     ulong      	net;
     ulong      	scc;
@@ -303,9 +306,9 @@ SCCofVCG(nodeVCGType * VCG,
 }
 
 void
-SCC_DFSAboveVCG(nodeVCGType * VCG,
+SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 		ulong net,
-		ulong * label)
+		_Ptr<ulong> label)
 {
     ulong	s;
     ulong 	above;
@@ -325,7 +328,7 @@ SCC_DFSAboveVCG(nodeVCGType * VCG,
 }
 
 void
-SCC_DFSBelowVCG(nodeVCGType * VCG,
+SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 		ulong net,
 		ulong label)
 {
@@ -346,23 +349,23 @@ SCC_DFSBelowVCG(nodeVCGType * VCG,
 }
 
 void
-DumpSCC(ulong * SCC,
-	ulong * perSCC)
+DumpSCC(_Array_ptr<ulong> SCC : count(channelNets + 1),
+		_Array_ptr<ulong> perSCC : count(totalSCC + 1))
 {
     ulong	net;
     ulong	scc;
 
     for (scc = 1; scc <= totalSCC; scc++) {
-	printf("[%d]\t", scc);
+	_Unchecked { printf("[%d]\t", scc); }
 	for (net = 1; net <= channelNets; net++) {
 	    if (SCC[net] == scc) {
-		printf("%d ", net);
+		_Unchecked { printf("%d ", net); }
 	    }
 	}
-	printf("<%d>", perSCC[scc]);
-	printf("\n");
+	_Unchecked { printf("<%d>", perSCC[scc]); }
+	_Unchecked { printf("\n"); }
     }
-    printf("\n");
+    _Unchecked { printf("\n"); }
 }
 
 void
@@ -488,20 +491,20 @@ AcyclicVCG(void)
 	}
     }
 
-    if (acyclic) {
+    if (acyclic) _Unchecked {
 	printf("\n*** Input is acyclic! ***\n");
     }
-    else {
+    else _Unchecked {
 	printf("\n*** Input is cyclic! ***\n");
 	printf("*** VC's removed (%d) ***\n", total);
     }
 }
 
 void
-RemoveConstraintVCG(nodeVCGType * VCG,
-		    ulong * SCC,
-		    ulong * perSCC,
-		    constraintVCGType * * removeVCG)
+RemoveConstraintVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
+					_Array_ptr<ulong> SCC : count(channelNets + 1),
+					_Array_ptr<ulong> perSCC : count(totalSCC + 1),
+		            _Array_ptr<_Ptr<constraintVCGType>> removeVCG : count((channelNets + 1) * (channelNets + 1)))
 {
     ulong			scc;
     ulong			net;
@@ -511,7 +514,7 @@ RemoveConstraintVCG(nodeVCGType * VCG,
     ulong			top;
     ulong			bot;
     ulong			col;
-    constraintVCGType *	remove;
+    _Ptr<constraintVCGType>	remove = NULL;
 
     for (scc = 1; scc <= totalSCC; scc++) {
 	/*
@@ -638,7 +641,7 @@ RemoveConstraintVCG(nodeVCGType * VCG,
 }
 
 ulong
-ExistPathAboveVCG(nodeVCGType * VCG,
+ExistPathAboveVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 		  ulong above,
 		  ulong below)
 {
@@ -648,7 +651,7 @@ ExistPathAboveVCG(nodeVCGType * VCG,
 }
 
 void
-LongestPathVCG(nodeVCGType * VCG,
+LongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	       ulong net)
 {
     ulong	track;
@@ -712,7 +715,7 @@ LongestPathVCG(nodeVCGType * VCG,
 }
 
 ulong
-DFSAboveLongestPathVCG(nodeVCGType * VCG,
+DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 		       ulong net)
 {
     ulong	s;
@@ -738,7 +741,7 @@ DFSAboveLongestPathVCG(nodeVCGType * VCG,
 }
 
 ulong
-DFSBelowLongestPathVCG(nodeVCGType * VCG,
+DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 		       ulong net)
 {
     ulong	s;
@@ -764,10 +767,10 @@ DFSBelowLongestPathVCG(nodeVCGType * VCG,
 }
 
 ulong
-VCV(nodeVCGType * VCG,
+VCV(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ulong check,
     ulong track,
-    ulong * assign)
+    _Array_ptr<ulong> assign : count(channelNets + 1))
 {
     ulong	net;
     ulong	vcv;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
@@ -18,6 +18,7 @@
 #ifndef VCG_H
 #define VCG_H
 
+#pragma BOUNDS_CHECKED ON
 /*
  *
  * Defines.
@@ -46,11 +47,11 @@ typedef struct _constraintVCGType {
 } constraintVCGType;
 
 typedef struct _nodeVCGType {
-    constraintVCGType *	netsAboveHook;
+    _Array_ptr<constraintVCGType>	netsAboveHook : count(netsAbove + 1);
     ulong			netsAbove;
     ulong			netsAboveLabel;
     ulong			netsAboveReached;
-    constraintVCGType *	netsBelowHook;
+    _Array_ptr<constraintVCGType>	netsBelowHook : count(netsBelow + 1);
     ulong			netsBelow;
     ulong			netsBelowLabel;
     ulong			netsBelowReached;
@@ -63,29 +64,31 @@ typedef struct _nodeVCGType {
  *
  */
 
+extern ulong channelNets;
+
 #ifdef VCG_CODE
 
-nodeVCGType *			VCG;
-constraintVCGType *			storageRootVCG;
-constraintVCGType *			storageVCG;
+_Array_ptr<nodeVCGType>			VCG : count(channelNets + 1);
+_Array_ptr<constraintVCGType>			storageRootVCG : count((channelNets + 1) * (channelNets + 1));
+_Array_ptr<constraintVCGType>			storageVCG : bounds(storageRootVCG, storageRootVCG + (channelNets + 1) * (channelNets + 1));
 ulong					storageLimitVCG;
-constraintVCGType * *		removeVCG;
+_Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) * (channelNets + 1));
 ulong					removeTotalVCG;
-ulong *				SCC;
+_Array_ptr<ulong>				SCC : count(channelNets + 1);
 ulong					totalSCC;
-ulong *				perSCC;
+_Array_ptr<ulong>				perSCC : count(totalSCC + 1);
 
 #else	/* VCG_CODE */
 
-extern nodeVCGType *			VCG;
-extern constraintVCGType *		storageRootVCG;
-extern constraintVCGType *		storageVCG;
-extern ulong				storageLimitVCG;
-extern constraintVCGType * *	removeVCG;
-extern ulong				removeTotalVCG;
-extern ulong *			SCC;
-extern ulong				totalSCC;
-extern ulong *			perSCC;
+extern _Array_ptr<nodeVCGType>			VCG : count(channelNets + 1);
+extern _Array_ptr<constraintVCGType>			storageRootVCG : count((channelNets + 1) * (channelNets + 1));
+extern _Array_ptr<constraintVCGType>			storageVCG : bounds(storageRootVCG, storageRootVCG + (channelNets + 1) * (channelNets + 1));
+extern ulong					storageLimitVCG;
+extern _Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) * (channelNets + 1));
+extern ulong					removeTotalVCG;
+extern _Array_ptr<ulong>				SCC : count(channelNets + 1);
+extern ulong					totalSCC;
+extern _Array_ptr<ulong>				perSCC : count(totalSCC + 1);
 
 #endif	/* VCG_CODE */
 
@@ -108,69 +111,69 @@ void
 BuildVCG(void);
 
 void
-DFSClearVCG(nodeVCGType *);
+DFSClearVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
 void
-DumpVCG(nodeVCGType *);
+DumpVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
 void
-DFSAboveVCG(nodeVCGType *,
+DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	    ulong);
 
 void
-DFSBelowVCG(nodeVCGType *,
+DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	    ulong);
 
 void
-SCCofVCG(nodeVCGType *,
-	 ulong *,
-	 ulong *);
+SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+		 _Array_ptr<ulong> : count(channelNets + 1),
+         _Array_ptr<ulong> : count(totalSCC + 1));
 
 void
-SCC_DFSAboveVCG(nodeVCGType *,
-		ulong,
-		ulong *);
+SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+				ulong,
+				_Ptr<ulong>);
 
 void
-SCC_DFSBelowVCG(nodeVCGType *,
+SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		ulong,
 		ulong);
 
 void
-DumpSCC(ulong *,
-	ulong *);
+DumpSCC(_Array_ptr<ulong> : count(channelNets + 1),
+	    _Array_ptr<ulong> : count(totalSCC + 1));
 
 void
 AcyclicVCG(void);
 
 void
-RemoveConstraintVCG(nodeVCGType *,
-		    ulong *,
-		    ulong *,
-		    constraintVCGType * *);
+RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+					_Array_ptr<ulong> : count(channelNets + 1),
+					_Array_ptr<ulong> : count(totalSCC + 1),
+					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
 
 ulong
-ExistPathAboveVCG(nodeVCGType *,
-		  ulong,
-		  ulong);
+ExistPathAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+				  ulong above,
+				  ulong below);
 
 void
-LongestPathVCG(nodeVCGType *,
+LongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	       ulong);
 
 ulong
-DFSAboveLongestPathVCG(nodeVCGType *,
+DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		       ulong);
 
 ulong
-DFSBelowLongestPathVCG(nodeVCGType *,
+DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		       ulong);
 
 ulong
-VCV(nodeVCGType *,
+VCV(_Array_ptr<nodeVCGType> : count(channelNets + 1),
     ulong,
     ulong,
-    ulong *);
+    _Array_ptr<ulong> : count(channelNets + 1));
 
 #else	/* VCG_CODE */
 
@@ -184,70 +187,71 @@ extern void
 BuildVCG(void);
 
 extern void
-DFSClearVCG(nodeVCGType *);
+DFSClearVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
 extern void
-DumpVCG(nodeVCGType *);
+DumpVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1));
 
 extern void
-DFSAboveVCG(nodeVCGType *,
+DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	    ulong);
 
 extern void
-DFSBelowVCG(nodeVCGType *,
+DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	    ulong);
 
 extern void
-SCCofVCG(nodeVCGType *,
-	 ulong *,
-	 ulong *);
+SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+		 _Array_ptr<ulong> : count(channelNets + 1),
+		 _Array_ptr<ulong> : count(totalSCC + 1));
 
 extern void
-SCC_DFSAboveVCG(nodeVCGType *,
-		ulong,
-		ulong *);
+SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+				ulong,
+				_Ptr<ulong>);
 
 extern void
-SCC_DFSBelowVCG(nodeVCGType *,
+SCC_DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		ulong,
 		ulong);
 
 extern void
-DumpSCC(ulong *,
-	ulong *);
+DumpSCC(_Array_ptr<ulong> : count(channelNets + 1),
+		_Array_ptr<ulong> : count(totalSCC + 1));
 
 extern void
 AcyclicVCG(void);
 
 extern void
-RemoveConstraintVCG(nodeVCGType *,
-		    ulong *,
-		    ulong *,
-		    constraintVCGType * *);
+RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+					_Array_ptr<ulong> : count(channelNets + 1),
+					_Array_ptr<ulong> : count(totalSCC + 1),
+					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
 
 extern ulong
-ExistPathAboveVCG(nodeVCGType *,
+ExistPathAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		  ulong,
 		  ulong);
 
 extern void
-LongestPathVCG(nodeVCGType *,
+LongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 	       ulong);
 
 extern ulong
-DFSAboveLongestPathVCG(nodeVCGType *,
+DFSAboveLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		       ulong);
 
 extern ulong
-DFSBelowLongestPathVCG(nodeVCGType *,
+DFSBelowLongestPathVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		       ulong);
 
 extern ulong
-VCV(nodeVCGType *,
-    ulong,
-    ulong,
-    ulong *);
+VCV(_Array_ptr<nodeVCGType> : count(channelNets + 1),
+	ulong,
+	ulong,
+	_Array_ptr<ulong> : count(channelNets + 1));
 
 #endif	/* VCG_CODE */
 
+#pragma BOUNDS_CHECKED OFF
 #endif	/* VCG_H */


### PR DESCRIPTION
I think this conversion is complete, but unoptimised.

The overall quality of code in this benchmark was infuriating. Lots of globals, lots passed as parameters sometimes but not always. Lots of parameter bounds contain lvalue reads of globals. If we want to avoid this we're going to be passing a lot more parameters everywhere. I had to introduce an intermediate struct in one place.

I don't really have an idea how much slower this is than its pre-converted form. I'll get an idea when I re-run the benchmarks.