### PR TITLE
Add missing bounds declaration found by compiler.

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/yacr2/maze.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/maze.c
@@ -648,7 +648,7 @@ Maze1(void)
  * can this track be extended to the range specified, return result
  */
 int
-ExtendOK(unsigned long net, _Array_ptr<char> plane,
+ExtendOK(unsigned long net, _Array_ptr<char> plane : count((channelColumns + 1)*(channelTracks + 3)),
 	 unsigned long _x1, unsigned long _y1,	/* start seg */
 	 unsigned long _x2, unsigned long _y2)	/* end seg */
 {


### PR DESCRIPTION
The compiler now checks that call arguments have bounds when parameters have bounds.  This found a small issue Ptrdist/yacr2 where a bounds declaration was omitted.  Add the missing bounds.

This fixed is needed for the compiler work for https://github.com/Microsoft/checkedc-clang/issues/373.

