### PR TITLE
Strings now have checked array type in checked scopes.

### DIFF
--- a/MultiSource/Benchmarks/Olden/bh/newbh.c
+++ b/MultiSource/Benchmarks/Olden/bh/newbh.c
@@ -48,8 +48,7 @@ int old_subindex(icstruct ic, int l);
 
 _Unchecked
 int dealwithargs(int argc, _Array_ptr<char *> argv : count(argc));
-_Unchecked
-int error(char *msg);
+int error(char *msg : itype(_Nt_array_ptr<char>));
 
 int arg1;
 

--- a/MultiSource/Benchmarks/Olden/bh/util.c
+++ b/MultiSource/Benchmarks/Olden/bh/util.c
@@ -48,8 +48,7 @@ double xrand(double xl, double xh, double r)
  * ERROR: scream and die quickly.
  */
 
-_Unchecked
-error(char *msg)
+error(char *msg : itype(_Nt_array_ptr<char>)) _Unchecked
 {
     fprintf(stderr, msg);
     if (errno != 0)

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -252,7 +252,7 @@ _Array_ptr<char> pchDictionary : count(pchDictionarySize);               /* the 
 #define Zero(t) memset(t, 0, sizeof(t)) /* quickly zero out an integer array */
 
 /* Fatal -- print a message before expiring */
-_Unchecked void Fatal(char *pchMsg, unsigned u) {
+void Fatal(char *pchMsg : itype(_Nt_array_ptr<char>), unsigned u) _Unchecked {
     fprintf(stderr, pchMsg, u);
     exit(1);
 }


### PR DESCRIPTION
Add bounds-safe interfaces to a few error functions being called from checked scopes and passed string literals.  This is needed for the matching compiler change [here](https://github.com/Microsoft/checkedc-clang/pull/396).
