### PR TITLE
Fixes as emailed by David

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
+++ b/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
@@ -64,6 +64,7 @@ ReadNetList(_Nt_array_ptr<char> fname)
 	    exit(1));
 	(*prev).module = atol(strtok(NULL, " \t\n"))-1;
 	(*prev).next = NULL;
+	// TODO: Review after https://github.com/Microsoft/checkedc-clang/issues/424 is addressed
     _Nt_array_ptr<char> tok : bounds(unknown) = NULL;
 	while ((tok = strtok(NULL, " \t\n")) != NULL) {
 	    TRY(node = calloc(1, sizeof(Module)),

--- a/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
+++ b/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
@@ -55,7 +55,7 @@ ReadNetList(_Nt_array_ptr<char> fname)
 	fgets(line, BUF_LEN, inFile);
 	
 	/* net connections for "dest" */
-	dest = atol(strtok(line, " \t\n"))-1;
+	dest = atol(strtok((_Nt_array_ptr<char>)line, " \t\n"))-1;
 
 	/* parse out all the net module connections */
 	TRY(head = prev = calloc(1, sizeof(Module)),
@@ -64,7 +64,7 @@ ReadNetList(_Nt_array_ptr<char> fname)
 	    exit(1));
 	(*prev).module = atol(strtok(NULL, " \t\n"))-1;
 	(*prev).next = NULL;
-    _Nt_array_ptr<char> tok = NULL;
+    _Nt_array_ptr<char> tok : bounds(unknown) = NULL;
 	while ((tok = strtok(NULL, " \t\n")) != NULL) {
 	    TRY(node = calloc(1, sizeof(Module)),
 		node != NULL, "ReadData",

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/maze.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/maze.c
@@ -14,6 +14,8 @@
 #define min(a,b)	((a<b) ? a : b)
 #define max(a,b)	((a<b) ? b : a)
 
+#undef bzero
+void bzero(void * : byte_count(n), size_t n);
 
 /*
  *	plane allocation structures and routines


### PR DESCRIPTION
This adds:
- a cast to nt_array_ptr<char> for a _Checked array.
- adding `bounds(unknown)` to a nt array ptr declaration to avoid `count(0)` default, because there is no bounds on the return from `strtok`. This may or may not be correct behaviour. Someone needs to confirm with me.
- Add declaration for bzero to yacr2, because it's not in the c standard library.