### PR TITLE
Remove workaround for strtok from benchmark

### DIFF
--- a/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
+++ b/MultiSource/Benchmarks/Ptrdist/ks/KS-1.c
@@ -64,8 +64,7 @@ ReadNetList(_Nt_array_ptr<char> fname)
 	    exit(1));
 	(*prev).module = atol(strtok(NULL, " \t\n"))-1;
 	(*prev).next = NULL;
-	// TODO: Review after https://github.com/Microsoft/checkedc-clang/issues/424 is addressed
-    _Nt_array_ptr<char> tok : bounds(unknown) = NULL;
+    _Nt_array_ptr<char> tok = NULL;
 	while ((tok = strtok(NULL, " \t\n")) != NULL) {
 	    TRY(node = calloc(1, sizeof(Module)),
 		node != NULL, "ReadData",


### PR DESCRIPTION
The compiler isn't properly inferring bounds of count(0) for return interface types of the form `itype(_Nt_array_ptr)`.   We had to put a workaround for the use of `strtok`, which returns an `_Nt_array_ptr`.   With https://github.com/Microsoft/checkedc-clang/pull/461, we can put both  an interface type and a bounds on a return type, and declare the proper bounds for `strtok'.   We can remove the workaround.

