### PR TITLE
Disable SciMark for ARM and increase the runtime limit

### DIFF
--- a/MultiSource/Benchmarks/Makefile
+++ b/MultiSource/Benchmarks/Makefile
@@ -11,6 +11,11 @@ PARALLEL_DIRS := Fhourstones Fhourstones-3.1 \
                  nbench ASCI_Purple MiBench Trimaran VersaBench NPB-serial\
                  BitBench ASC_Sequoia TSVC DOE-ProxyApps-C
 
+# On ARM qemu, SciMark2-C takes ~18m to run. For now we disable it.
+ifeq ($(ARCH),ARM)
+PARALLEL_DIRS := $(filter-out SciMark2-C,$(PARALLEL_DIRS))
+endif
+
 # Disable TSVC on Darwin until the tests support SMALL_PROBLEM_SIZE=1.
 ifeq ($(TARGET_OS),Darwin)
 ifeq ($(ARCH),ARM)

--- a/MultiSource/Benchmarks/SciMark2-C/Makefile
+++ b/MultiSource/Benchmarks/SciMark2-C/Makefile
@@ -14,10 +14,15 @@ ifeq ($(ARCH),Mips)
 # Mips takes ~50 minutes.
 RUNTIMELIMIT := 3000
 else
+ifeq ($(ARCH),ARM)
+# On ARM we get very close to 1200s. Set it to a more comfortable value.
+RUNTIMELIMIT := 1500
+else
 ifeq ($(ARCH),AArch64)
 # On AArch64 at -O0 we get very close to 500s and sometimes we go over the
 # threshold. Set it to a more comfortable value.
 RUNTIMELIMIT := 750
+endif
 endif
 endif
 ifdef LARGE_PROBLEM_SIZE


### PR DESCRIPTION
On ARM qemu, SciMark takes ~1200s to run. We increase the runtime limit for
SciMark to ~1500s so that it does not get reported as fail. Also 1500s is a bit
too long for per patch LNT validations. So for now we disable SciMark for ARM
target.