### PR TITLE
Validate bounds context

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -340,7 +340,8 @@ ptr<graph_t> initialize_graph(void) {
   chatting("cleanup for return now\n");
   for (i=0; i<NumNodes; i++) {
     int local_table_size = table->e_table[i*blocksize].size;
-    array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+    int local_table_bounds = local_table_size;
+    array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
     _Unchecked { local_table = table->e_table[i*blocksize].table; }
     ptr<node_t> local_node_r = local_table[0];
 

--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -212,7 +212,7 @@ void make_tables(ptr<table_t> table,int groupname) {
 void make_all_neighbors(ptr<table_t> table,int groupname) {
   ptr<node_t> first_node = NULL;
   int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  array_ptr<ptr<node_t>> local_table : count(1) = NULL;
   array_ptr<table_arr_t> local_table_array : count(1) = NULL;
 
   init_random(SEED2*groupname);
@@ -237,7 +237,7 @@ void make_all_neighbors(ptr<table_t> table,int groupname) {
 void update_all_from_coeffs(ptr<table_t> table, int groupname)    
 {
   int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  array_ptr<ptr<node_t>> local_table : count(1) = NULL;
   ptr<node_t> first_node = NULL;
 
   /* Done by do_all, table not local */
@@ -256,7 +256,7 @@ void update_all_from_coeffs(ptr<table_t> table, int groupname)
 void fill_all_from_fields(ptr<table_t> table, int groupname)
 {
   int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  array_ptr<ptr<node_t>> local_table : count(1) = NULL;
   ptr<node_t> first_node = NULL;
 
   init_random(SEED3*groupname);
@@ -274,7 +274,7 @@ void fill_all_from_fields(ptr<table_t> table, int groupname)
 void localize(ptr<table_t> table, int groupname)
 {
   int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  array_ptr<ptr<node_t>> local_table : count(1) = NULL;
   ptr<node_t> first_node = NULL;
 
   local_table_size = table->h_table[groupname].size;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -286,6 +286,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     /*
      * Identify all SCC.
      */
+    ulong originalTotalSCC = totalSCC;
     totalSCC = 0;
     for (net = 1; net <= channelNets; net++) {
 	SCC[net] = VCG[net].netsBelowLabel;


### PR DESCRIPTION
This PR updates test files so that they compile without errors, to account for new compiler errors introduced by [checkedc-clang/853](https://github.com/microsoft/checkedc-clang/pull/853).

If a variable `v` is used in the bounds of a variable `p`, and `v` is modified without an original value, then the observed bounds of `v` will be unknown. This is a compiler error as of [checkedc-clang/853](https://github.com/microsoft/checkedc-clang/pull/853) that occurred in two llvm test suite files.