### PR TITLE
Fix Olden and Ptrdist benchmarks

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -211,8 +211,9 @@ void make_tables(ptr<table_t> table,int groupname) {
 
 void make_all_neighbors(ptr<table_t> table,int groupname) {
   ptr<node_t> first_node = NULL;
-  int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  int local_table_size = 1;
+  int local_table_bounds = local_table_size;
+  array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
   array_ptr<table_arr_t> local_table_array : count(1) = NULL;
 
   init_random(SEED2*groupname);
@@ -236,8 +237,9 @@ void make_all_neighbors(ptr<table_t> table,int groupname) {
 
 void update_all_from_coeffs(ptr<table_t> table, int groupname)    
 {
-  int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  int local_table_size = 1;
+  int local_table_bounds = local_table_size;
+  array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
   ptr<node_t> first_node = NULL;
 
   /* Done by do_all, table not local */
@@ -255,8 +257,9 @@ void update_all_from_coeffs(ptr<table_t> table, int groupname)
 
 void fill_all_from_fields(ptr<table_t> table, int groupname)
 {
-  int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  int local_table_size = 1;
+  int local_table_bounds = local_table_size;
+  array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
   ptr<node_t> first_node = NULL;
 
   init_random(SEED3*groupname);
@@ -273,8 +276,9 @@ void fill_all_from_fields(ptr<table_t> table, int groupname)
 
 void localize(ptr<table_t> table, int groupname)
 {
-  int local_table_size;
-  array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+  int local_table_size = 1;
+  int local_table_bounds = local_table_size;
+  array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
   ptr<node_t> first_node = NULL;
 
   local_table_size = table->h_table[groupname].size;
@@ -340,7 +344,8 @@ ptr<graph_t> initialize_graph(void) {
   chatting("cleanup for return now\n");
   for (i=0; i<NumNodes; i++) {
     int local_table_size = table->e_table[i*blocksize].size;
-    array_ptr<ptr<node_t>> local_table : count(local_table_size) = NULL;
+    int local_table_bounds = local_table_size;
+    array_ptr<ptr<node_t>> local_table : count(local_table_bounds) = NULL;
     _Unchecked { local_table = table->e_table[i*blocksize].table; }
     ptr<node_t> local_node_r = local_table[0];
 

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -229,7 +229,7 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 void
 SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	     _Array_ptr<ulong> SCC : count(channelNets + 1),
-		 _Array_ptr<ulong> perSCC : count(totalSCC + 1))
+		 _Array_ptr<ulong> paramSCC : count(totalSCC + 1))
 {
     ulong      	net;
     ulong      	scc;
@@ -240,6 +240,9 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ulong	large;
     ulong	done;
     ;
+
+    ulong originalTotalSCC = totalSCC;
+    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = paramSCC;
 
     /*
      * DFS of above edges.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -242,8 +242,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 
     ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1);
-    perSCC = paramSCC;
+    _Array_ptr<ulong> perSCC : count(originalTotalSCC) = paramSCC;
 
     /*
      * DFS of above edges.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -242,7 +242,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 
     ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = tmpPerSCC;
+    _Array_ptr<ulong> perSCC : count(totalSCC + 1) = tmpPerSCC;
 
     /*
      * DFS of above edges.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -229,7 +229,7 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 void
 SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	     _Array_ptr<ulong> SCC : count(channelNets + 1),
-		 _Array_ptr<ulong> paramSCC : count(totalSCC + 1))
+		 _Array_ptr<ulong> tmpPerSCC : count(totalSCC + 1))
 {
     ulong      	net;
     ulong      	scc;
@@ -242,7 +242,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 
     ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = paramSCC;
+    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = tmpPerSCC;
 
     /*
      * DFS of above edges.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -242,7 +242,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 
     ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(originalTotalSCC) = paramSCC;
+    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = paramSCC;
 
     /*
      * DFS of above edges.

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -242,7 +242,8 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ;
 
     ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1) = paramSCC;
+    _Array_ptr<ulong> perSCC : count(originalTotalSCC + 1);
+    perSCC = paramSCC;
 
     /*
      * DFS of above edges.


### PR DESCRIPTION
This PR updates test files so that they compile without errors, to account for new compiler errors introduced by checkedc-clang/853.

If a variable v is used in the bounds of a variable p, and v is modified without an original value, then the observed bounds of v will be unknown. This is a compiler error as of checkedc-clang/853 that occurred in two llvm test suite files.