### PR TITLE
Fix compile errors related to free variables

### DIFF
--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -18,9 +18,9 @@ static array_ptr<void> localmalloc(int size) : byte_count(size)
   
   if (size>remaining) 
     {
-      temp = calloc<char>(32768, sizeof(char));
-      if (!temp) printf("Error! malloc returns null\n");
       remaining = 32768;
+      temp = calloc<char>(remaining, sizeof(char));
+      if (!temp) printf("Error! malloc returns null\n");
     }
   blah = temp;
   temp += size;

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -638,8 +638,8 @@ void SortCandidates(void) {
 
 int fInteractive;
 
-_Array_ptr<char> GetPhrase(_Array_ptr<char> pch : bounds(achPhrase, achPhrase+size), int size)
-    : bounds(achPhrase, achPhrase+size) {
+_Array_ptr<char> GetPhrase(_Array_ptr<char> pch : count(size), int size)
+    : count(size) {
     if (fInteractive) printf(">");
     fflush(stdout);
     _Unchecked { if (fgets(pch, size, stdin) == NULL) _Checked {

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -293,9 +293,9 @@ void ReadDict(_Nt_array_ptr<char> pchFile) {
     unsigned long ulLen;
     pchDictionarySize = ulLen = statBuf.st_size + 2 * (unsigned long)MAXWORDS;
     _Array_ptr<char> buffer : count(ulLen) = 0;
-    _Array_ptr<char> pch : bounds(buffer, buffer+ulLen) = 0;
     _Array_ptr<char> pchBase : bounds(buffer, buffer+ulLen) = 0;
     pchBase = buffer = pchDictionary = calloc<char>(pchDictionarySize, sizeof(char));
+    _Array_ptr<char> pch : bounds(buffer, buffer+ulLen) = 0;
 
     if(pchDictionary == NULL)
 	Fatal("Unable to allocate memory for dictionary\n", 0);

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -40,8 +40,8 @@ AllocVCG(void)
     storageVCG = storageRootVCG;
     storageLimitVCG = (channelNets + 1) * (channelNets + 1);
     SCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
-	perSCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
-	removeVCG = malloc<_Ptr<constraintVCGType>>((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
+    perSCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
+    removeVCG = malloc<_Ptr<constraintVCGType>>((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
 }
 
 void
@@ -291,7 +291,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     for (net = 1; net <= channelNets; net++) {
 	SCC[net] = VCG[net].netsBelowLabel;
 	if (SCC[net] > totalSCC) {
-		totalSCC = SCC[net];
+	    totalSCC = SCC[net];
 	}
     }
     assert(totalSCC > 0);

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -229,7 +229,8 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 void
 SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 	     _Array_ptr<ulong> SCC : count(channelNets + 1),
-		 _Array_ptr<ulong> tmpPerSCC : count(totalSCC + 1))
+		 _Array_ptr<ulong> perSCC : count(countSCC + 1),
+		 ulong countSCC)
 {
     ulong      	net;
     ulong      	scc;
@@ -240,9 +241,6 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     ulong	large;
     ulong	done;
     ;
-
-    ulong originalTotalSCC = totalSCC;
-    _Array_ptr<ulong> perSCC : count(totalSCC + 1) = tmpPerSCC;
 
     /*
      * DFS of above edges.
@@ -404,7 +402,7 @@ AcyclicVCG(void)
 	 * Check acyclic (and more).
 	 */
 	DFSClearVCG(VCG);
-	SCCofVCG(VCG, SCC, perSCC);
+	SCCofVCG(VCG, SCC, perSCC, channelNets);
 	for (scc = 1; scc <= totalSCC; scc++) {
 	    if (perSCC[scc] > 1) {
 		acyclic = FALSE;
@@ -461,7 +459,7 @@ AcyclicVCG(void)
 	 */
 	cycle = FALSE;
 	DFSClearVCG(VCG);
-	SCCofVCG(VCG, SCC, perSCC);
+	SCCofVCG(VCG, SCC, perSCC, channelNets);
 	for (scc = 1; scc <= totalSCC; scc++) {
 	    if (perSCC[scc] > 1) {
 		cycle = TRUE;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.c
@@ -40,8 +40,8 @@ AllocVCG(void)
     storageVCG = storageRootVCG;
     storageLimitVCG = (channelNets + 1) * (channelNets + 1);
     SCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
-    perSCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
-    removeVCG = malloc<_Ptr<constraintVCGType>>((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
+	perSCC = malloc<ulong>((channelNets + 1) * sizeof(ulong));
+	removeVCG = malloc<_Ptr<constraintVCGType>>((channelNets + 1) * (channelNets + 1) * sizeof(constraintVCGType *));
 }
 
 void
@@ -291,7 +291,7 @@ SCCofVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
     for (net = 1; net <= channelNets; net++) {
 	SCC[net] = VCG[net].netsBelowLabel;
 	if (SCC[net] > totalSCC) {
-	    totalSCC = SCC[net];
+		totalSCC = SCC[net];
 	}
     }
     assert(totalSCC > 0);
@@ -505,7 +505,7 @@ AcyclicVCG(void)
 void
 RemoveConstraintVCG(_Array_ptr<nodeVCGType> VCG : count(channelNets + 1),
 					_Array_ptr<ulong> SCC : count(channelNets + 1),
-					_Array_ptr<ulong> perSCC : count(totalSCC + 1),
+					_Array_ptr<ulong> perSCC : count(channelNets + 1),
 		            _Array_ptr<_Ptr<constraintVCGType>> removeVCG : count((channelNets + 1) * (channelNets + 1)))
 {
     ulong			scc;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
@@ -150,7 +150,7 @@ AcyclicVCG(void);
 void
 RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(totalSCC + 1),
+					_Array_ptr<ulong> : count(channelNets + 1),
 					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
 
 ulong
@@ -227,7 +227,7 @@ AcyclicVCG(void);
 extern void
 RemoveConstraintVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 					_Array_ptr<ulong> : count(channelNets + 1),
-					_Array_ptr<ulong> : count(totalSCC + 1),
+					_Array_ptr<ulong> : count(channelNets + 1),
 					_Array_ptr<_Ptr<constraintVCGType>> : count((channelNets + 1) * (channelNets + 1)));
 
 extern ulong

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
@@ -76,7 +76,7 @@ _Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) * (chan
 ulong					removeTotalVCG;
 _Array_ptr<ulong>				SCC : count(channelNets + 1);
 ulong					totalSCC;
-_Array_ptr<ulong>				perSCC : count(totalSCC + 1);
+_Array_ptr<ulong>				perSCC : count(channelNets + 1);
 
 #else	/* VCG_CODE */
 
@@ -88,7 +88,7 @@ extern _Array_ptr<_Ptr<constraintVCGType>>		removeVCG : count((channelNets + 1) 
 extern ulong					removeTotalVCG;
 extern _Array_ptr<ulong>				SCC : count(channelNets + 1);
 extern ulong					totalSCC;
-extern _Array_ptr<ulong>				perSCC : count(totalSCC + 1);
+extern _Array_ptr<ulong>				perSCC : count(channelNets + 1);
 
 #endif	/* VCG_CODE */
 

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
@@ -127,7 +127,8 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 void
 SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		 _Array_ptr<ulong> : count(channelNets + 1),
-         _Array_ptr<ulong> : count(totalSCC + 1));
+         _Array_ptr<ulong> : count(countSCC + 1),
+		 ulong countSCC);
 
 void
 SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
@@ -203,7 +204,8 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 extern void
 SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		 _Array_ptr<ulong> : count(channelNets + 1),
-		 _Array_ptr<ulong> : count(totalSCC + 1));
+		 _Array_ptr<ulong> : count(countSCC + 1),
+		 ulong countSCC);
 
 extern void
 SCC_DFSAboveVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/vcg.h
@@ -127,7 +127,7 @@ DFSBelowVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 void
 SCCofVCG(_Array_ptr<nodeVCGType> : count(channelNets + 1),
 		 _Array_ptr<ulong> : count(channelNets + 1),
-         _Array_ptr<ulong> : count(countSCC + 1),
+		 _Array_ptr<ulong> : count(countSCC + 1),
 		 ulong countSCC);
 
 void


### PR DESCRIPTION
This PR fixes compile errors that occurred in the Olden and Ptrdist benchmarks due to the changes in [checkedc-clang/#903](https://github.com/microsoft/checkedc-clang/pull/903). The checkedc-clang PR detects free variables in declared and inferred bounds and emits a compiler error if free variables are found.

This PR changes some declared bounds and reorders some code so that no free variables are involved in declared and inferred bounds. In particular:

* The bounds of the global `totalSCC` array pointer. in vcg.h use `channelNets` rather than `totalSCC` in the declared bounds (`totalSCC` is allocated using `channelNets`).
* The `SCCofVCG` method in vcg.c accepts an additional parameter for the length of the `perSCC` array pointer. Many functions in vcg.c reference global variables in parameter bounds. Continuing to clean up these global references is a future work item #100.
* The `GetPhrase` method in anagram.c references the parameter `pch` rather than the global `achPhrase` in its declared bounds.
* Some assignments and declarations are reordered to avoid free variables in declared and inferred bounds.