### PR TITLE
Fix calls to ResultCode after clang 11 upgrade

### DIFF
--- a/litsupport/test.py
+++ b/litsupport/test.py
@@ -13,8 +13,8 @@ import litsupport.testplan
 import os
 
 
-SKIPPED = lit.Test.ResultCode('SKIPPED', False)
-NOEXE = lit.Test.ResultCode('NOEXE', True)
+SKIPPED = lit.Test.ResultCode('SKIPPED', 'Skipped', False)
+NOEXE = lit.Test.ResultCode('NOEXE', 'NoExe', True)
 
 
 class TestSuiteTest(lit.formats.ShTest):


### PR DESCRIPTION
After upgrading checkedc-clang to release 11, we see that the signature of
ResultCode in lit has changed and it now expects 3 parameters. But our
checkedc-llvm-test-suite has not been updated and continues to pass only 2
parameters in calls to ResultCode. This causes the following error in the Linux
LNT Benchmarking ADO run:

"TypeError: __new__() takes exactly 4 arguments (3 given)"

Here we are making/fixing calls to ResultCode similar to those in
https://github.com/microsoft/checkedc-clang/blob/master/llvm/utils/lit/lit/Test.py#L45

The long term fix is to upgrade the checkedc-llvm-test-suite. Issue https://github.com/microsoft/checkedc-clang/issues/992 tracks this.