### PR TITLE
[LValue Generalization] Update benchmark tests for validating member bounds

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -74,8 +74,7 @@ void make_neighbors(ptr<node_t> nodelist, array_ptr<table_arr_t> table : count(P
     array_ptr<ptr<node_t>> tmp : count(degree) = calloc<ptr<node_t>>(degree, (sizeof(ptr<node_t>)));
     dynamic_check(tmp != NULL);
 
-    cur_node->degree = degree;
-    _Unchecked { cur_node->to_nodes = tmp; }
+    _Unchecked { cur_node->degree = degree, cur_node->to_nodes = tmp; }
 
     for (j=0; j<degree; j++) {
       do {
@@ -209,10 +208,14 @@ void make_tables(ptr<table_t> table,int groupname) {
 
   /* This is done on procname-- we expect table to be remote */
   /* We use remote writes */
-  table->e_table[groupname].size = n_nodes/PROCS;
-  table->h_table[groupname].size = n_nodes/PROCS;
-  _Unchecked { table->e_table[groupname].table = e_table; }
-  _Unchecked { table->h_table[groupname].table = h_table; }
+  _Unchecked {
+    table->e_table[groupname].size = n_nodes/PROCS,
+      table->e_table[groupname].table = e_table;
+  }
+  _Unchecked {
+    table->h_table[groupname].size = n_nodes/PROCS,
+      table->h_table[groupname].table = h_table;
+  }
 }
 
 void make_all_neighbors(ptr<table_t> table,int groupname) {

--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -42,14 +42,18 @@ void fill_table(array_ptr<ptr<node_t>> node_table : count(size), array_ptr<doubl
   node_table[0] = prev_node;
   *values = gen_uniform_double();
   _Unchecked { prev_node->value = values++; }
-  prev_node->from_count = 0;
+  prev_node->from_count = 0,
+    prev_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(prev_node->from_values, count(prev_node->from_count)),
+    prev_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(prev_node->coeffs, count(prev_node->from_count));
   
   /* Now we fill the node_table with allocated nodes */
   for (i=1; i<size; i++) {
     cur_node = calloc<node_t>(1, sizeof(node_t));
     *values = gen_uniform_double();
     _Unchecked { cur_node->value = values++; }
-    cur_node->from_count = 0;
+    cur_node->from_count = 0,
+      cur_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(cur_node->from_values, count(cur_node->from_count)),
+      cur_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(cur_node->coeffs, count(cur_node->from_count));
     node_table[i] = cur_node;
     prev_node->next = cur_node;
     prev_node = cur_node;
@@ -120,7 +124,9 @@ void make_neighbors(ptr<node_t> nodelist, array_ptr<table_arr_t> table : count(P
       if ((((unsigned long long) other_node) >> 7) < 2048)
         chatting("post other_node = 0x%x\n",other_node);
 #endif
-      ++other_node->from_count;            /* <----- 12% load miss penalty */
+      ++other_node->from_count,            /* <----- 12% load miss penalty */
+          other_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(other_node->from_values, count(other_node->from_count)),
+          other_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(other_node->coeffs, count(other_node->from_count));
     }
   }
 }

--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -36,8 +36,8 @@ Hash MakeHash(int size, ptr<int(unsigned int)> map)
   int i;
 
   retval = (Hash) localmalloc(sizeof(*retval));
-  retval->array = (array_ptr<HashEntry>)localmalloc(size*sizeof(HashEntry));
-  retval->size = size;
+  retval->size = size,
+    retval->array = (array_ptr<HashEntry>)localmalloc(size*sizeof(HashEntry));
   for (i=0; i<size; i++)
     retval->array[i] = NULL;
   retval->mapfunc = map;

--- a/MultiSource/Benchmarks/Olden/mst/makegraph.c
+++ b/MultiSource/Benchmarks/Olden/mst/makegraph.c
@@ -102,9 +102,11 @@ Graph MakeGraph(int numvert, int numproc)
           tmp->next = v;
           v = tmp;
         }
-      _Unchecked { retval->vlist[j].block = block; }
-      retval->vlist[j].len = perproc;
-      _Unchecked { retval->vlist[j].starting_vertex = v; }
+      _Unchecked {
+        retval->vlist[j].len = perproc,
+          retval->vlist[j].block = block,
+          retval->vlist[j].starting_vertex = v;
+      }
     }
 
   chatting("Make phase 3\n");

--- a/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
+++ b/MultiSource/Benchmarks/Ptrdist/anagram/anagram.c
@@ -447,8 +447,7 @@ void BuildWord(_Array_ptr<char> pchWord : bounds(wordStart, wordEnd),
     pw = NextWord();
     bzero(pw->aqMask, sizeof(Quad)*MAX_QUADS);
     /* Zero(pw->aqMask); */
-    _Unchecked { pw->pchWord = pchWord; }
-    pw->cchLength = cchLength;
+    _Unchecked { pw->cchLength = cchLength, pw->pchWord = pchWord; }
     for (i = 0; i < ALPHABET; i++) {
         pw->aqMask[alPhrase[i].iq] |=
             (Quad)cchFrequency[i] << alPhrase[i].uShift;

--- a/MultiSource/Benchmarks/Ptrdist/yacr2/assign.c
+++ b/MultiSource/Benchmarks/Ptrdist/yacr2/assign.c
@@ -42,8 +42,8 @@ AllocAssign(void)
      */
     costMatrix = malloc<struct costMatrixRow>((channelNets+1) * sizeof(struct costMatrixRow));
     for (net = 1; net <= channelNets; net++) {
-	costMatrix[net].len = channelTracks + 2;
-	costMatrix[net].row = malloc<long>((channelTracks+2) * sizeof(long));
+	costMatrix[net].len = channelTracks + 2,
+	  costMatrix[net].row = malloc<long>((channelTracks+2) * sizeof(long));
     }
 
     /*


### PR DESCRIPTION
This PR updates test files to account for the new compiler behavior introduced by [checkedc-clang/1083](https://github.com/microsoft/checkedc-clang/pull/1083): validating the bounds context for member expressions. The compiler now emits errors and warnings for statements that invalidate member bounds by assigning to member expressions that are used in member bounds.

There are new compiler errors emitted for a noninvertible assignment to a member expression `s->i`, where `s->i` is used by the declared bounds of `s->p`. The updates to the test files fall into the following categories:
1. If there is no assignment to `s->p` in the function where the assignment to `s->i` occurs: use a `_Dynamic_bounds_cast` to reestablish the declared bounds of `s->p`.
2. If there is an assignment to `s->p` in the function where the assignment to `s->i` occurs: move the assignment to `s->p` to the same statement as the assignment to `s->i`. In other words, convert `s->i = e1; ... s->p = e2;` to `s->i = e1, s->p = e2;`. This ensures that, at the end of checking the statement `s->i = e1, s->p = e2;`, the bounds of `s->p` will be valid (assuming the assignment `s->p = e2` does not invalidate the bounds of `s->p`).
3. In some cases, the assignment to `s->p` occurs within an `_Unchecked` statement. Move the assignment to `s->i` within the `_Unchecked` statement as well. In other words, convert `s->i = e1; ... _Unchecked { s->p = e2; }` to `_Unchecked { s->i = e1, s->p = e2; }`