### PR TITLE
Check return value bounds: update test

### DIFF
--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -14,7 +14,7 @@ static array_ptr<char> temp : count(remaining);
 
 static array_ptr<void> localmalloc(int size) : byte_count(size)
 {
-  array_ptr<void> blah;
+  array_ptr<void> blah : byte_count(size) = 0;
   
   if (size>remaining) 
     {
@@ -22,7 +22,7 @@ static array_ptr<void> localmalloc(int size) : byte_count(size)
       temp = calloc<char>(remaining, sizeof(char));
       if (!temp) printf("Error! malloc returns null\n");
     }
-  blah = temp;
+  blah = _Dynamic_bounds_cast<array_ptr<void>>(temp, byte_count(size));
   temp += size;
   remaining -= size;
   return blah;


### PR DESCRIPTION
This PR updates the hash.c test file to account for the compiler behavior in [checkedc-clang/1150](https://github.com/microsoft/checkedc-clang/pull/1150): checking that the inferred bounds of a return expression imply the declared bounds (if any) for the enclosing function.

There was one function `localmalloc` in hash.c that returned a variable `blah` with unknown bounds, which resulted in a compile-time error. This PR declares the bounds `byte_count(size)` for `blah` to match the declared bounds `byte_count(size)` of the `localmalloc` function.