### PR TITLE
Bounds checking for pointer dereferences and array subscripts: update test

### DIFF
--- a/MultiSource/Benchmarks/Olden/mst/hash.c
+++ b/MultiSource/Benchmarks/Olden/mst/hash.c
@@ -89,7 +89,8 @@ void HashDelete(unsigned key, Hash hash) {
   assert(4, *ent);
 
   tmp = *ent;
-  *ent = (*ent)->next;
+  HashEntry temp_entry = (*ent)->next;
+  *ent = temp_entry;
   localfree(tmp);
 }
 


### PR DESCRIPTION
This PR updates the hash.c test to avoid a compiler error that would otherwise be triggered by the behavior in [checkedc-clang/1176](https://github.com/microsoft/checkedc-clang/pull/1176): assigning to a pointer dereference `*ent` with target bounds, where `*ent` in the source bounds of the RHS `(*ent)->next` of the assignment and `*ent` has no original value.

Instead, the test introduces a temporary variable `temp_entry` to hold the expression `(*ent)->next` and assigns `temp_entry` to `*ent`, so that the source bounds of the RHS `temp_entry` of the assignment to `*ent` do not use the value of `*ent`.