### PR TITLE
Get lvalue observed bounds: update test

### DIFF
--- a/MultiSource/Benchmarks/Olden/em3d/em3d.h
+++ b/MultiSource/Benchmarks/Olden/em3d/em3d.h
@@ -39,7 +39,7 @@ typedef struct node_t {
   array_ptr<ptr<struct node_t>> to_nodes : count(degree); /* array of nodes pointed to */
   array_ptr<ptr<double>> from_values : count(from_count); /* array of ptrs to vals where data comes from */
   array_ptr<double> coeffs : count(from_count); /* array of coeffs on edges */
-  int from_count;
+  unsigned int from_count;
   int from_length;
   int degree;
 } node_t;

--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -123,9 +123,7 @@ void make_neighbors(ptr<node_t> nodelist, array_ptr<table_arr_t> table : count(P
       if ((((unsigned long long) other_node) >> 7) < 2048)
         chatting("post other_node = 0x%x\n",other_node);
 #endif
-      other_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(other_node->from_values, count(0)),
-        other_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(other_node->coeffs, count(0)),
-        ++other_node->from_count;          /* <----- 12% load miss penalty */
+      ++other_node->from_count;          /* <----- 12% load miss penalty */
     }
   }
 }

--- a/MultiSource/Benchmarks/Olden/em3d/make_graph.c
+++ b/MultiSource/Benchmarks/Olden/em3d/make_graph.c
@@ -42,18 +42,18 @@ void fill_table(array_ptr<ptr<node_t>> node_table : count(size), array_ptr<doubl
   node_table[0] = prev_node;
   *values = gen_uniform_double();
   _Unchecked { prev_node->value = values++; }
-  prev_node->from_count = 0,
-    prev_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(prev_node->from_values, count(prev_node->from_count)),
-    prev_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(prev_node->coeffs, count(prev_node->from_count));
+  prev_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(prev_node->from_values, count(0)),
+    prev_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(prev_node->coeffs, count(0)),
+    prev_node->from_count = 0;
   
   /* Now we fill the node_table with allocated nodes */
   for (i=1; i<size; i++) {
     cur_node = calloc<node_t>(1, sizeof(node_t));
     *values = gen_uniform_double();
     _Unchecked { cur_node->value = values++; }
-    cur_node->from_count = 0,
-      cur_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(cur_node->from_values, count(cur_node->from_count)),
-      cur_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(cur_node->coeffs, count(cur_node->from_count));
+    cur_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(cur_node->from_values, count(0)),
+      cur_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(cur_node->coeffs, count(0)),
+      cur_node->from_count = 0;
     node_table[i] = cur_node;
     prev_node->next = cur_node;
     prev_node = cur_node;
@@ -123,9 +123,9 @@ void make_neighbors(ptr<node_t> nodelist, array_ptr<table_arr_t> table : count(P
       if ((((unsigned long long) other_node) >> 7) < 2048)
         chatting("post other_node = 0x%x\n",other_node);
 #endif
-      ++other_node->from_count,            /* <----- 12% load miss penalty */
-          other_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(other_node->from_values, count(other_node->from_count)),
-          other_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(other_node->coeffs, count(other_node->from_count));
+      other_node->from_values = _Dynamic_bounds_cast<array_ptr<ptr<double>>>(other_node->from_values, count(0)),
+        other_node->coeffs = _Dynamic_bounds_cast<array_ptr<double>>(other_node->coeffs, count(0)),
+        ++other_node->from_count;          /* <----- 12% load miss penalty */
     }
   }
 }


### PR DESCRIPTION
This PR updates the test file make_graph.c to account for the behavior in [checkedc-clang/1183](https://github.com/microsoft/checkedc-clang/pull/1183).

With this change, the bounds for the value of the member expression `prev_node->from_values` are the observed bounds for `prev_node->from_values` as recorded in `CheckingState.ObservedBounds`. This means that, after the assignment `prev_node->from_count = 0`, the observed bounds of `prev_node->from_values` are `bounds(unknown)`. This results in an error when attempting to use `prev_node->from_values` in a dynamic bounds cast.

This PR uses an initial dynamic bounds cast to set the observed bounds of `prev_node->from_values` to `bounds(prev_node->from_values, prev_node->from_values + 0)` so that the observed bounds do not depend on `prev_node->from_count`.